### PR TITLE
feat: add routeros-hotspot skill

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -289,6 +289,21 @@ vs manual). Allowed-address and routing interactions. Preshared-keys.
 WireGuard on RouterOS has a few idiosyncrasies around `mtu` and firewall
 interactions worth grounding.
 
+### `routeros-vrrp`
+
+VRRP (Virtual Router Redundancy Protocol) on RouterOS. LLMs often suggest Linux
+keepalived or HSRP syntax instead of RouterOS's native VRRP implementation.
+
+Key:
+- `/interface/vrrp/add` — creates VRRP virtual interface
+- `vrid=` + `priority=` + `preemption-mode=`
+- VRRP interface used as gateway in DHCP server networks and routing
+- Event hooks: `on-master=`, `on-backup=`, `on-fail=` — NOT `tracked-interface=`
+  or `script=` (those properties do not exist on `/interface/vrrp`)
+- Common mistake: treating VRRP interface like a regular bridge/ethernet interface
+
+Grounding: MikroTik "VRRP" help page, `/console/inspect` at `/interface/vrrp`.
+
 ### `routeros-files-and-backup`
 
 `/file` system, upload/download mechanisms (SCP, FTP, REST PUT, Winbox, WebFig),

--- a/routeros-hotspot/SKILL.md
+++ b/routeros-hotspot/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: routeros-hotspot
+description: "RouterOS hotspot captive portal for wired/wireless access control.
+  Use when: configuring hotspot on RouterOS, setting up captive portal,
+  writing hotspot profiles or instances, configuring walled garden,
+  setting DHCP option 114 (RFC 8910 captive portal URI), integrating
+  RADIUS with hotspot, or when the user mentions /ip/hotspot,
+  walled-garden, hotspot profile, or captive portal on MikroTik."
+---
+
+# RouterOS Hotspot
+
+## How Hotspot Chains Work
+
+Hotspot traffic intercept runs **before** the regular firewall input/forward chains. This is the single most important fact to internalize:
+
+- `/ip/hotspot` binds to a bridge or interface — all traffic on that interface enters the hotspot chain first
+- Firewall rules blocking TCP 80/443 from the hotspot interface do **NOT** block the captive portal login page — hotspot handles it before the firewall sees it
+- The firewall placeholder `action=passthrough chain=unused-hs-chain` must exist — RouterOS uses it as an anchor point for hotspot rules
+
+**Common mistake:** Adding a DROP rule for port 443 from bridge-hotspot to "fix a security gap" — this breaks the HTTPS login page silently.
+
+## Hotspot Profile
+
+```routeros
+/ip/hotspot/profile/add \
+  name=my-profile \
+  hotspot-address=10.20.0.1 \
+  login-by=https,mac,http-pap \
+  mac-auth-mode=mac-as-username-and-password \
+  dns-name=login.example.com \
+  ssl-certificate=login.example.com.crt_0 \
+  nas-port-type=ethernet \
+  use-radius=yes \
+  radius-accounting=yes \
+  html-directory-override=hotspot-files
+```
+
+Key properties:
+- `ssl-certificate=` — RouterOS appends `_0` on certificate import; reference the imported name, not the filename
+- `html-directory-override=` — must match the exact folder name on the router's filesystem
+- `login-by=https` — serves the login page over HTTPS; requires `www-ssl` service enabled with the same certificate
+- `use-radius=yes` — when set, **local `/ip/hotspot/user` entries are bypassed**; adding them has no effect
+
+## Hotspot Instance
+
+```routeros
+/ip/hotspot/add \
+  name=hotspot1 \
+  interface=bridge-hotspot \
+  profile=my-profile \
+  address-pool=pool-hotspot \
+  addresses-per-mac=2 \
+  idle-timeout=5m \
+  keepalive-timeout=none \
+  disabled=no
+```
+
+**Note:** `keepalive-timeout=none` disables the keepalive. `keepalive-timeout=0` is NOT valid — it is ignored.
+
+**Note:** RouterOS hotspot relies on NAT and is **IPv4-only**. IPv6 clients are not supported by the hotspot subsystem.
+
+## DHCP Option 114 — Captive Portal API (RFC 8910)
+
+Option 114 (standardized 2020, RFC 8910) signals the captive portal URI to clients. It is underrepresented in LLM training data.
+
+```routeros
+# force=yes is REQUIRED — without it, clients whose DHCP Parameter Request
+# List does not include code 114 (e.g. iOS, Android) silently skip the option
+/ip/dhcp-server/option/add \
+  name=captive-portal \
+  code=114 \
+  force=yes \
+  value="'https://login.example.com/api'"
+
+/ip/dhcp-server/option/sets/add \
+  name=captive-portal-set \
+  options=captive-portal
+
+/ip/dhcp-server/set my-dhcp-server dhcp-option-set=captive-portal-set
+```
+
+**Option value syntax:** outer double quotes, inner single quotes — `"'https://...'"`. Missing inner quotes cause the option to be sent as a binary blob, not a string URI.
+
+**api.json timing:** RouterOS creates `hotspot/api.json` only after the **first client CAPPORT probe** — not at hotspot enable time. Move it to the html-directory-override folder after first client connects:
+
+```routeros
+# Handles both flash/ and non-flash storage layouts
+:local srcPath "hotspot/api.json"
+:local dstPath "hotspot-files/api.json"
+:if ([:len [/file find name="flash"]] > 0) do={
+  :set srcPath "flash/hotspot/api.json"
+  :set dstPath "flash/hotspot-files/api.json"
+}
+:if ([:len [/file find name=$srcPath]] > 0) do={
+  /file set [find name=$srcPath] name=$dstPath
+} else={
+  :log warning "api.json not yet created — run after first client CAPPORT probe"
+}
+```
+
+## Walled Garden
+
+Use a consistent `comment=` tag for idempotent add/remove. Without it, repeated script runs accumulate duplicate entries.
+
+```routeros
+# Remove only our entries, not manually-added ones
+/ip/hotspot/walled-garden/ip/remove [find comment="my-wg"]
+
+/ip/hotspot/walled-garden/ip
+add dst-host=example.com   action=accept comment="my-wg"
+add dst-host=*.example.com action=accept comment="my-wg"
+```
+
+**IP vs HTTP walled garden:**
+- `/ip/hotspot/walled-garden/ip` — layer 3 match by destination host, applied BEFORE authentication. Use for HTTPS destinations.
+- `/ip/hotspot/walled-garden` — layer 7 URL pattern match, requires HTTP. Does NOT work for HTTPS.
+
+## SSL Certificate Note
+
+The hotspot profile references `ssl-certificate=name.crt_0` (RouterOS appends `_0` on import). Enable `www-ssl` with the same certificate:
+
+```routeros
+/ip/service/set www-ssl disabled=no certificate=login.example.com.crt_0 tls-version=only-1.2
+```
+
+For the full certificate download → import pattern, see the `routeros-certificates` skill (planned).
+
+## External Captive Portal — HTML Template Variables
+
+RouterOS substitutes `$(variable)` server-side in all HTML files from `html-directory-override` before serving them. These are **not** JavaScript variables — they are filled before the browser receives the page.
+
+| Variable | Description |
+|---|---|
+| `$(link-login-only)` | RouterOS login URL (without redirect) — pass to external auth |
+| `$(link-orig)` | Original URL the client requested |
+| `$(server-name)` | Hotspot instance name |
+| `$(mac)` | Client MAC address |
+| `$(ip)` | Client IP address |
+| `$(error-orig)` | Error message from previous auth attempt |
+| `$(logged-in)` | `yes` if client is already authenticated |
+
+Generic `login.html` pattern for external captive portal:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="pragma" content="no-cache">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- External auth provider loads redirect logic -->
+  <script src='https://auth.example.com/snippets/router-os/redirect'></script>
+</head>
+<body>
+  <div id="entryPoint">Redirecting...</div>
+  <script>
+    window.addEventListener('load', function () {
+      ExternalAuth_redirect(
+        '$(server-name)', '$(mac)', '$(link-login-only)',
+        '$(link-orig)', '$(error-orig)', '$(logged-in)', '$(ip)'
+      );
+    });
+  </script>
+</body>
+</html>
+```
+
+The external provider authenticates the user and redirects back to the `$(link-login-only)` URL with auth tokens. RouterOS then completes the login.
+
+## Common LLM Mistakes
+
+| Mistake | Correct behavior |
+|---------|-----------------|
+| DROP TCP 443 from hotspot interface | Hotspot chain runs before firewall — breaks the HTTPS login page |
+| `keepalive-timeout=0` to disable keepalive | Use `keepalive-timeout=none` |
+| Option 114 `value=` without inner single quotes | Must be `"'https://...'"` — outer double, inner single |
+| Option 114 without `force=yes` | iOS/Android silently skip option if not in their DHCP PRL |
+| Adding `/ip/hotspot/user` when `use-radius=yes` | Local users are bypassed when RADIUS is active |
+| Wildcard HTTPS domains in `/ip/hotspot/walled-garden` | Use `/ip/hotspot/walled-garden/ip` for HTTPS (layer 3 match) |
+| Hotspot on dual-stack network with IPv6 | Hotspot is IPv4-only — IPv6 not supported |
+| `$(link-login)` treated as JavaScript variable | It is RouterOS server-side substitution, not JS |
+
+## RADIUS Integration
+
+See [references/radius-client.md](./references/radius-client.md) for RADIUS client configuration patterns.

--- a/routeros-hotspot/SKILL.md
+++ b/routeros-hotspot/SKILL.md
@@ -16,7 +16,7 @@ Hotspot traffic intercept runs **before** the regular firewall input/forward cha
 
 - `/ip/hotspot` binds to a bridge or interface — all traffic on that interface enters the hotspot chain first
 - Firewall rules blocking TCP 80/443 from the hotspot interface do **NOT** block the captive portal login page — hotspot handles it before the firewall sees it
-- The firewall placeholder `action=passthrough chain=unused-hs-chain` must exist — RouterOS uses it as an anchor point for hotspot rules
+- RouterOS automatically injects dynamic firewall rules (`hs-unauth`, `hs-auth` chains) — do not manually create, remove, or interfere with these hotspot-managed rules
 
 **Common mistake:** Adding a DROP rule for port 443 from bridge-hotspot to "fix a security gap" — this breaks the HTTPS login page silently.
 
@@ -30,14 +30,14 @@ Hotspot traffic intercept runs **before** the regular firewall input/forward cha
   mac-auth-mode=mac-as-username-and-password \
   dns-name=login.example.com \
   ssl-certificate=login.example.com.crt_0 \
-  nas-port-type=ethernet \
+  nas-port-type=ethernet \   # use wireless-ieee-802-11-g for wireless hotspots
   use-radius=yes \
   radius-accounting=yes \
   html-directory-override=hotspot-files
 ```
 
 Key properties:
-- `ssl-certificate=` — RouterOS appends `_0` on certificate import; reference the imported name, not the filename
+- `ssl-certificate=` — reference the name after import (RouterOS appends `_0` to imported certificate names)
 - `html-directory-override=` — must match the exact folder name on the router's filesystem
 - `login-by=https` — serves the login page over HTTPS; requires `www-ssl` service enabled with the same certificate
 - `use-radius=yes` — when set, **local `/ip/hotspot/user` entries are bypassed**; adding them has no effect
@@ -107,9 +107,8 @@ Use a consistent `comment=` tag for idempotent add/remove. Without it, repeated 
 # Remove only our entries, not manually-added ones
 /ip/hotspot/walled-garden/ip/remove [find comment="my-wg"]
 
-/ip/hotspot/walled-garden/ip
-add dst-host=example.com   action=accept comment="my-wg"
-add dst-host=*.example.com action=accept comment="my-wg"
+/ip/hotspot/walled-garden/ip/add dst-host=example.com   action=accept comment="my-wg"
+/ip/hotspot/walled-garden/ip/add dst-host=*.example.com action=accept comment="my-wg"
 ```
 
 **IP vs HTTP walled garden:**
@@ -124,7 +123,12 @@ The hotspot profile references `ssl-certificate=name.crt_0` (RouterOS appends `_
 /ip/service/set www-ssl disabled=no certificate=login.example.com.crt_0 tls-version=only-1.2
 ```
 
-For the full certificate download → import pattern, see the `routeros-certificates` skill (planned).
+Quick import pattern:
+```routeros
+/certificate import file-name=login.example.com.crt passphrase=""
+/certificate import file-name=login.example.com.key passphrase=""
+# After import, the certificate appears as login.example.com.crt_0
+```
 
 ## External Captive Portal — HTML Template Variables
 
@@ -133,6 +137,7 @@ RouterOS substitutes `$(variable)` server-side in all HTML files from `html-dire
 | Variable | Description |
 |---|---|
 | `$(link-login-only)` | RouterOS login URL (without redirect) — pass to external auth |
+| `$(link-login)` | Full login URL with `?dst=` redirect appended — use `$(link-login-only)` for external auth to avoid double-encoding the redirect |
 | `$(link-orig)` | Original URL the client requested |
 | `$(server-name)` | Hotspot instance name |
 | `$(mac)` | Client MAC address |
@@ -180,6 +185,19 @@ The external provider authenticates the user and redirects back to the `$(link-l
 | Wildcard HTTPS domains in `/ip/hotspot/walled-garden` | Use `/ip/hotspot/walled-garden/ip` for HTTPS (layer 3 match) |
 | Hotspot on dual-stack network with IPv6 | Hotspot is IPv4-only — IPv6 not supported |
 | `$(link-login)` treated as JavaScript variable | It is RouterOS server-side substitution, not JS |
+
+## Additional Resources
+
+**Related skills:**
+- `routeros-fundamentals` — RouterOS CLI syntax, REST API, scripting basics
+- `routeros-certificates` (planned) — certificate download, import, and chain verification
+
+**MCP tools:**
+- `rosetta` MCP server — `/tool/ping`, `/ip/hotspot` command tree inspection (`routeros_search`, `routeros_get_page`)
+
+**MikroTik docs:**
+- [HotSpot](https://help.mikrotik.com/docs/display/ROS/HotSpot) — official reference
+- [DHCP Server](https://help.mikrotik.com/docs/display/ROS/DHCP) — option 114 configuration
 
 ## RADIUS Integration
 

--- a/routeros-hotspot/SKILL.md
+++ b/routeros-hotspot/SKILL.md
@@ -132,18 +132,49 @@ Quick import pattern:
 
 ## External Captive Portal — HTML Template Variables
 
-RouterOS substitutes `$(variable)` server-side in all HTML files from `html-directory-override` before serving them. These are **not** JavaScript variables — they are filled before the browser receives the page.
+RouterOS substitutes `$(variable)` server-side in any file under `html-directory-override` before serving it. These are **not** JavaScript variables — they are filled before the browser receives the page.
+
+**Servlet pages RouterOS serves** (drop your own to override):
+`login.html`, `flogin.html` (failed-login), `alogin.html` (post-success), `status.html`, `logout.html`, `error.html`, `redirect.html`, `rlogin.html`, `rstatus.html`, `fstatus.html`, `flogout.html`, `radvert.html`, `md5.js`, `errors.txt`. Most external-CP setups only need `login.html` + `alogin.html` + `status.html`.
+
+**Most-used variables for external CP:**
 
 | Variable | Description |
 |---|---|
-| `$(link-login-only)` | RouterOS login URL (without redirect) — pass to external auth |
-| `$(link-login)` | Full login URL with `?dst=` redirect appended — use `$(link-login-only)` for external auth to avoid double-encoding the redirect |
-| `$(link-orig)` | Original URL the client requested |
+| `$(link-login-only)` | Login POST endpoint **without** `?dst=` — preferred for external auth (avoids double-encoding) |
+| `$(link-login)` | Login URL **with** `?dst=` redirect appended |
+| `$(link-orig)` / `$(link-orig-esc)` | Original URL the client requested. **Use `-esc` when interpolating into another URL** |
 | `$(server-name)` | Hotspot instance name |
-| `$(mac)` | Client MAC address |
-| `$(ip)` | Client IP address |
-| `$(error-orig)` | Error message from previous auth attempt |
+| `$(mac)` / `$(mac-esc)` | Client MAC (raw / URL-escaped) |
+| `$(ip)` | Client IP |
+| `$(host-ip)` | IP from hotspot host table (differs from `$(ip)` under one-to-one NAT) |
+| `$(interface-name)`, `$(vlan-id)` | Useful for tenant-aware external auth |
+| `$(error)` / `$(error-orig)` | Localized vs raw error from previous auth attempt |
 | `$(logged-in)` | `yes` if client is already authenticated |
+| `$(trial)` | `yes` if trial access still available for this MAC |
+| `$(username)` / `$(username-esc)` | Authenticated username (status page) |
+| `$(bytes-in[-nice])`, `$(bytes-out[-nice])`, `$(uptime[-secs])`, `$(session-time-left[-secs])` | Status-page counters |
+| `$(radius<id>[u])`, `$(radius<id>-<vnd-id>[u])` | Pass-through of RADIUS Access-Accept attributes — text or unsigned int. Empty / `"0"` when local-DB auth (`use-radius=no`) |
+| `$(http-header-<Name>)` | **Read** an incoming request header — e.g. `$(http-header-User-Agent)`, `$(http-header-Accept-Language)` |
+| `$(if http-status == XYZ)MSG$(endif)` | **Set** the HTTP response status code |
+| `$(if http-header == NAME)VALUE$(endif)` | **Set** a custom response header (different syntax from the read pattern above) |
+
+**Always pick the `-esc` variant** (`$(link-orig-esc)`, `$(mac-esc)`, `$(username-esc)`) when embedding a value into a URL or query string. The non-escaped variants will break parsing or open injection paths if the value contains `&`, `=`, `?`, `#`.
+
+**POST form fields** RouterOS accepts at `$(link-login-only)`:
+`username`, `password`, `domain`, `dst`, `popup`, `session-id`, `var`, `erase-cookie`, `target` (multi-language subdir).
+
+**Conditional syntax** (server-side, not JavaScript):
+
+```
+$(if logged-in == "yes")
+  <a href="$(link-logout)">Logout</a>
+$(else)
+  <form action="$(link-login-only)" method="post">...</form>
+$(endif)
+```
+
+Operators: presence (`$(if VAR)`), `==`, `!=`. Also `$(elif ...)`. No nested arithmetic / string ops.
 
 Generic `login.html` pattern for external captive portal:
 
@@ -162,8 +193,8 @@ Generic `login.html` pattern for external captive portal:
   <script>
     window.addEventListener('load', function () {
       ExternalAuth_redirect(
-        '$(server-name)', '$(mac)', '$(link-login-only)',
-        '$(link-orig)', '$(error-orig)', '$(logged-in)', '$(ip)'
+        '$(server-name)', '$(mac-esc)', '$(link-login-only)',
+        '$(link-orig-esc)', '$(error-orig)', '$(logged-in)', '$(ip)'
       );
     });
   </script>
@@ -171,7 +202,11 @@ Generic `login.html` pattern for external captive portal:
 </html>
 ```
 
-The external provider authenticates the user and redirects back to the `$(link-login-only)` URL with auth tokens. RouterOS then completes the login.
+The external provider authenticates the user and redirects the browser back to `$(link-login-only)` with `username` + `password` + `dst` POST fields. RouterOS validates (local DB or RADIUS), issues the auth cookie, and redirects to `dst`.
+
+**Walled-garden must include the external auth host (and any CDN/asset hosts)** — otherwise the unauthenticated browser cannot reach the redirect script in step 2.
+
+Full variable reference, all servlet pages, RADIUS pass-through patterns, multi-language `target=` mechanics, and HTTP response control: see [references/template-variables.md](./references/template-variables.md).
 
 ## Common LLM Mistakes
 
@@ -185,6 +220,8 @@ The external provider authenticates the user and redirects back to the `$(link-l
 | Wildcard HTTPS domains in `/ip/hotspot/walled-garden` | Use `/ip/hotspot/walled-garden/ip` for HTTPS (layer 3 match) |
 | Hotspot on dual-stack network with IPv6 | Hotspot is IPv4-only — IPv6 not supported |
 | `$(link-login)` treated as JavaScript variable | It is RouterOS server-side substitution, not JS |
+| Embedding `$(link-orig)` / `$(mac)` / `$(username)` into another URL | Use the `-esc` variant — non-esc breaks parsing on `&`, `=`, `?` and may enable injection |
+| Hotspot with PCC / multiple routing tables | Hotspot uses only the default routing table — split-WAN setups need explicit `/ip route rule` for hotspot traffic |
 
 ## Additional Resources
 

--- a/routeros-hotspot/SKILL.md
+++ b/routeros-hotspot/SKILL.md
@@ -190,7 +190,7 @@ The external provider authenticates the user and redirects back to the `$(link-l
 
 **Related skills:**
 - `routeros-fundamentals` — RouterOS CLI syntax, REST API, scripting basics
-- `routeros-certificates` (planned) — certificate download, import, and chain verification
+- `routeros-certificates` (in backlog) — for the full certificate chain handling pattern
 
 **MCP tools:**
 - `rosetta` MCP server — `/tool/ping`, `/ip/hotspot` command tree inspection (`routeros_search`, `routeros_get_page`)

--- a/routeros-hotspot/references/radius-client.md
+++ b/routeros-hotspot/references/radius-client.md
@@ -1,0 +1,72 @@
+# RADIUS Client Configuration
+
+RouterOS RADIUS client for hotspot authentication. Referenced from `routeros-hotspot` SKILL.md.
+
+## Multi-Server Pattern
+
+RouterOS tries RADIUS servers in list order and falls back to the next on timeout. Add at least two entries for redundancy:
+
+```routeros
+/radius add \
+  address=185.1.2.3 \
+  secret="your-shared-secret" \
+  service=hotspot \
+  timeout=3s \
+  comment="radius-primary"
+
+/radius add \
+  address=185.1.2.4 \
+  secret="your-shared-secret" \
+  service=hotspot \
+  timeout=3s \
+  comment="radius-secondary"
+```
+
+## Initial Disabled State
+
+In automated deployments, create RADIUS entries as `disabled=yes` and enable them only after the hotspot HTML files and certificates are ready:
+
+```routeros
+# At deploy time — disabled until hotspot files are ready
+/radius add address=185.1.2.3 secret="..." service=hotspot timeout=3s \
+  comment="my-radius" disabled=yes
+
+# After hotspot files downloaded:
+/radius enable [find comment~"my-radius"]
+```
+
+This prevents the hotspot from serving auth requests before the login page exists.
+
+## Secret Management
+
+Never hardcode RADIUS secrets in scripts. Use a template variable:
+
+```routeros
+# In OptiWize or similar template systems:
+# <<radius_secret>> is substituted at deploy time
+/radius add address=185.1.2.3 secret="<<radius_secret>>" service=hotspot \
+  timeout=3s comment="my-radius" disabled=yes
+```
+
+## `[:resolve]` Trap
+
+`[:resolve "radius.example.com"]` returns **only the first A record**. If the RADIUS server has multiple IPs for redundancy, only one is used. Use explicit IP variables:
+
+```routeros
+# BAD — only gets 1 IP even if DNS has multiple A records
+:local radiusIp [:resolve "radius.example.com"]
+
+# GOOD — use explicit IPs
+/radius add address="185.1.2.3" secret="..." service=hotspot comment="radius-1" disabled=yes
+/radius add address="185.1.2.4" secret="..." service=hotspot comment="radius-2" disabled=yes
+```
+
+## Enable Pattern
+
+After hotspot files are downloaded, enable all RADIUS entries tagged with a shared comment:
+
+```routeros
+/radius enable [find comment~"my-radius"]
+```
+
+This is idempotent — running it again on already-enabled entries has no effect.

--- a/routeros-hotspot/references/template-variables.md
+++ b/routeros-hotspot/references/template-variables.md
@@ -1,0 +1,244 @@
+# Hotspot HTML Template Variables — Full Reference
+
+RouterOS substitutes `$(name)` placeholders **server-side** before serving any file from `html-directory-override`. Substitution happens in HTML, JS embedded in HTML, and `errors.txt`. The browser never sees the `$(...)` tokens.
+
+Source: <https://help.mikrotik.com/docs/spaces/ROS/pages/87162881/Hotspot+customisation>
+
+---
+
+## Servlet Pages
+
+RouterOS serves these filenames from the html-directory. All accept template variables.
+
+| File | When served |
+|------|-------------|
+| `login.html` | Authentication form (unauthenticated client requests any URL) |
+| `flogin.html` | Login page after a failed attempt — falls back to `login.html` if missing |
+| `alogin.html` | Shown immediately after a successful login (popup/redirect handler) |
+| `status.html` | Authenticated status page (session stats, logout button) |
+| `rstatus.html` | Status redirect when client requests `/status` while logged in |
+| `fstatus.html` | Status request from unauthenticated client |
+| `logout.html` | Post-logout confirmation |
+| `flogout.html` | Logout request from unauthenticated client |
+| `rlogin.html` | Login redirect when client hits a restricted URL |
+| `redirect.html` | Generic URL redirector |
+| `error.html` | Fatal error page |
+| `radvert.html` | Advertisement redirector (when `advertise=yes` profile flag set) |
+| `md5.js` | Client-side MD5 helper for CHAP login |
+| `errors.txt` | Localized error message strings |
+
+External captive portal typically only customizes `login.html` + `alogin.html` + `status.html`. The rest can stay default.
+
+---
+
+## POST Form Fields
+
+Fields RouterOS expects when the browser submits to `$(link-login-only)`:
+
+| Field | Purpose |
+|-------|---------|
+| `username` | Username (or MAC for mac-auth) |
+| `password` | Plaintext (HTTP-PAP) or `response` after CHAP hashing |
+| `domain` | Optional domain suffix — combined per `radius-default-domain` / `split-user-domain` |
+| `dst` | Original URL to redirect to after login |
+| `popup` | `true` to open status page as popup |
+| `session-id` | CHAP session id (echoed from `$(chap-id)`) |
+| `var` | Free-form custom variable, accessible as `$(var)` in templates |
+| `erase-cookie` | `on`/`true` on logout — drops the auth cookie so auto-login won't trigger |
+| `target` | Subdirectory selector for multi-language templates (`target=de` → `/de/login.html`) |
+
+---
+
+## Common Server Variables
+
+| Variable | Description |
+|---|---|
+| `$(hostname)` | DNS name (or IP if no DNS) of the hotspot servlet |
+| `$(identity)` | RouterOS `/system/identity` value |
+| `$(server-name)` | Hotspot instance name |
+| `$(server-address)` | Hotspot servlet IP:port |
+| `$(login-by)` | Auth method actually used (`cookie`, `http-chap`, `http-pap`, `https`, `mac`, `mac-cookie`, `trial`) |
+| `$(plain-passwd)` | `yes` if HTTP-PAP enabled in profile, else `no` |
+| `$(ssl-login)` | `yes` if current connection is HTTPS, else `no` |
+
+## Link Variables
+
+| Variable | Description |
+|---|---|
+| `$(link-login)` | Full login URL **including** `?dst=<orig>` redirect |
+| `$(link-login-only)` | Login URL **without** `dst` — preferred for external auth (avoids double-encoding) |
+| `$(link-logout)` | Logout URL |
+| `$(link-status)` | Status page URL |
+| `$(link-orig)` | Original URL the client requested |
+| `$(link-orig-esc)` | URL-escaped variant — **use this** when embedding `link-orig` into another URL/query string |
+| `$(link-redirect)` | Custom redirect target |
+
+**Security:** Always pick the `-esc` variant when interpolating into another URL, query string, or attribute value. The non-escaped variants can break URL parsing or open injection paths if the original URL contains `&`, `=`, `?`, or `#`.
+
+## Client Variables
+
+| Variable | Description |
+|---|---|
+| `$(username)` / `$(username-esc)` | Authenticated username (raw / URL-escaped) |
+| `$(domain)` | Domain part if `split-user-domain=yes` |
+| `$(ip)` | Client IP address |
+| `$(mac)` / `$(mac-esc)` | Client MAC (raw `XX:XX:XX:XX:XX:XX` / URL-escaped) |
+| `$(host-ip)` | IP from `/ip/hotspot/host` table — differs from `$(ip)` when one-to-one NAT applies |
+| `$(interface-name)` | Physical hotspot interface (or bridge) the client is on |
+| `$(vlan-id)` | VLAN ID if client is on a tagged interface |
+| `$(logged-in)` | `yes` / `no` |
+| `$(trial)` | `yes` if trial access still available for this MAC |
+| `$(user-agent)` | Browser User-Agent string (shortcut for `$(http-header-User-Agent)`) |
+| `$(http-header-<Name>)` | Read any incoming HTTP request header — e.g. `$(http-header-Accept-Language)`, `$(http-header-Referer)`. Header name is case-sensitive as sent by the client. |
+
+## Session / Limit Variables
+
+Available on `status.html` (and any post-login page).
+
+| Variable | Description |
+|---|---|
+| `$(session-timeout)` | Remaining session time, formatted (`5h30m`) |
+| `$(session-timeout-secs)` | Same, in seconds |
+| `$(session-time-left)` / `$(session-time-left-secs)` | Time left until forced logout |
+| `$(idle-timeout)` / `$(idle-timeout-secs)` | Idle disconnect timer |
+| `$(refresh-timeout)` / `$(refresh-timeout-secs)` | Status page auto-refresh interval |
+| `$(uptime)` / `$(uptime-secs)` | Current session duration |
+| `$(bytes-in)` / `$(bytes-in-nice)` | Bytes received from user (raw / human-readable) |
+| `$(bytes-out)` / `$(bytes-out-nice)` | Bytes sent to user |
+| `$(packets-in)` / `$(packets-out)` | Packet counters |
+| `$(limit-bytes-in)` / `$(limit-bytes-out)` | Quota limits from profile/RADIUS |
+| `$(remain-bytes-in)` / `$(remain-bytes-out)` | Quota remaining |
+
+## Auth / Error Variables
+
+| Variable | Description |
+|---|---|
+| `$(error)` | Localized error message (looked up in `errors.txt`) |
+| `$(error-orig)` | Untranslated raw error string — stable for programmatic matching |
+| `$(chap-id)` | CHAP challenge ID (login.html only) |
+| `$(chap-challenge)` | CHAP challenge value (login.html only) |
+| `$(popup)` | `true` / `false` — was login popup-mode |
+| `$(advert-pending)` | `yes` if a forced advertisement popup is queued |
+
+## RADIUS Pass-Through
+
+Direct access to attributes from the RADIUS Access-Accept reply:
+
+| Variable | Description |
+|---|---|
+| `$(radius<id>)` | Attribute `<id>` as text string (e.g. `$(radius27)` for Session-Timeout) |
+| `$(radius<id>u)` | Attribute as unsigned integer |
+| `$(radius<id>-<vnd-id>)` | Vendor-specific attribute (text) |
+| `$(radius<id>-<vnd-id>u)` | Vendor-specific attribute (unsigned) |
+
+Empty string (text variants) or `"0"` (unsigned variants) when local-DB auth (no `use-radius=yes`).
+
+## HTTP Request / Response Control
+
+**Reading request headers:** use `$(http-header-<HeaderName>)` — direct substitution, no conditional needed. Header name is case-sensitive as sent by the client. Examples:
+
+```
+Detected language: $(http-header-Accept-Language)
+$(if http-header-User-Agent == "MyKioskApp/1.0")
+  ...kiosk-specific markup...
+$(endif)
+```
+
+**Setting response status / headers:** use the `$(if ...)` form — note that `http-status` and `http-header` (without dash + name) are **special tokens** the substitution engine recognizes:
+
+```
+$(if http-status == 302)Found$(endif)
+$(if http-header == Location)https://example.com/welcome$(endif)
+```
+
+First produces `HTTP/1.0 302 Found`; second adds `Location: https://example.com/welcome`. Useful for `redirect.html` / `alogin.html` programmatic redirects without HTML/JS.
+
+The two patterns coexist: `$(http-header-User-Agent)` reads, `$(if http-header == Location)...$(endif)` writes.
+
+---
+
+## Conditional Syntax
+
+```
+$(if VAR)
+  shown when VAR is non-empty
+$(elif VAR == "value")
+  shown when VAR equals "value"
+$(elif VAR != "other")
+  shown when VAR not equal "other"
+$(else)
+  fallback
+$(endif)
+```
+
+Comparisons supported: presence (non-empty), `==`, `!=`. No arithmetic, no string concat, no nested complex expressions documented. Strings may be quoted or bare.
+
+Common patterns:
+
+```html
+$(if error)
+  <div class="error">$(error)</div>
+$(endif)
+
+$(if logged-in == "yes")
+  <a href="$(link-logout)">Logout</a>
+$(else)
+  <form action="$(link-login-only)" method="post">...</form>
+$(endif)
+
+$(if trial == "yes")
+  <button name="trial" value="yes">Free 30 minutes</button>
+$(endif)
+```
+
+---
+
+## Multi-Language Templates
+
+1. Create subdirectories per language: `hotspot-files/de/`, `hotspot-files/fr/`, etc.
+2. Drop translated `login.html`, `errors.txt`, etc. into each.
+3. Pass `target=de` as a POST/GET parameter — RouterOS prefixes the path with that subdirectory for subsequent requests.
+
+Selector pattern in `login.html`:
+
+```html
+<form action="$(link-login-only)" method="post">
+  <input type="hidden" name="target" value="de">
+  ...
+</form>
+```
+
+---
+
+## Escaping Rules
+
+| Suffix | What it does |
+|---|---|
+| `-esc` | URL-encodes the value (`&` → `%26`, `=` → `%3D`, space → `%20`, etc.) |
+| `-nice` | "User-friendly" formatting of a numeric value. Upstream docs do not specify the exact format (separators vs. unit-conversion); treat as opaque display string and don't parse programmatically — use the raw counter (e.g. `$(bytes-in)`) when you need an integer |
+
+There is **no HTML-escape variant**. If a variable can contain user-controlled data (e.g. `$(username)`, `$(error-orig)` reflecting form input), do not interpolate it directly into HTML attributes or `<script>` blocks without your own escaping. Safe spots: text nodes inside elements that don't allow HTML.
+
+---
+
+## External Captive Portal Flow
+
+```
+1. Unauth client requests any URL
+   → RouterOS serves login.html with $(link-login-only), $(mac), $(link-orig-esc)
+2. login.html JS posts client info to external auth provider (auth.example.com)
+3. External provider authenticates user, stores session
+4. External provider redirects browser to:
+     $(link-login-only)?username=<u>&password=<p>&dst=$(link-orig-esc)
+5. RouterOS validates credentials (local DB or RADIUS), issues cookie, redirects to dst
+6. Subsequent requests pass via cookie auth (login-by=cookie)
+```
+
+Walled-garden must allow `auth.example.com` (and any CDN/asset hosts) **before** the client authenticates — otherwise step 2 cannot reach the external provider.
+
+---
+
+## See Also
+
+- Captive portal overview: <https://help.mikrotik.com/docs/spaces/ROS/pages/56459266/HotSpot+-+Captive+portal>
+- Customisation reference: <https://help.mikrotik.com/docs/spaces/ROS/pages/87162881/Hotspot+customisation>


### PR DESCRIPTION
## Summary

- Adds `routeros-hotspot` skill covering captive portal configuration for RouterOS v7
- Covers: hotspot chain architecture (runs before firewall), hotspot profile/instance setup, DHCP option 114 (RFC 8910) with `force=yes`, `api.json` timing/flash path, walled garden comment-tag pattern, SSL certificate note, external captive portal HTML template variables (`$(...)` server-side substitution), common LLM mistakes
- Includes `references/radius-client.md` — multi-server pattern, disabled initial state, `[:resolve]` one-IP trap, enable-after-files pattern
- Adds `routeros-vrrp` to BACKLOG.md under M priority (correct event hooks: `on-master=`, `on-backup=`, `on-fail=`)

## Grounded from

- Production RouterOS scripts ([CloudWiFi](https://cloudwifi.de/?lang=en) hotspot deployment, ~3000 devices, RouterOS 7.x)


## Test plan

- [ ] SKILL.md frontmatter YAML is valid
- [ ] All 8 content sections present
- [ ] `references/radius-client.md` resolves from relative link
- [ ] `routeros-vrrp` entry in BACKLOG.md with correct property names