### PR TITLE
feat: add routeros-firewall skill

### DIFF
--- a/routeros-firewall/SKILL.md
+++ b/routeros-firewall/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: routeros-firewall
+description: "RouterOS firewall filter, NAT, mangle, and address-list configuration.
+  Use when: writing firewall rules in RouterOS, configuring NAT, setting up
+  address-lists or interface-lists, writing idempotent firewall scripts,
+  configuring DNS redirect or port forwarding, or when the user mentions
+  /ip/firewall, chain=forward, chain=input, connection-state, address-list,
+  interface-list, or layer7-protocol on MikroTik."
+---
+
+# RouterOS Firewall
+
+## Rule Ordering — Sequential, Not Priority-Based
+
+Rules are evaluated **top-to-bottom** — first match wins. This is the biggest source of iptables confusion.
+
+- `place-before=0` inserts at the top; default `add` appends at the bottom
+- An `action=accept` rule must appear BEFORE any `action=drop` for the same traffic
+- **Non-terminal actions do NOT stop evaluation:** `action=add-src-to-address-list`, `action=add-dst-to-address-list`, `action=log`, and any rule with `passthrough=yes` continue to the next rule. A `drop` rule below an `add-src-to-address-list` will still fire.
+
+```routeros
+# WRONG — drop fires before accept can match
+/ip/firewall/filter/add chain=input action=drop
+/ip/firewall/filter/add chain=input src-address=10.0.0.1 action=accept
+
+# CORRECT — accept first, drop catches the rest
+/ip/firewall/filter/add chain=input src-address=10.0.0.1 action=accept place-before=0
+/ip/firewall/filter/add chain=input action=drop
+```
+
+## Address-Lists as Dynamic Selectors
+
+LLMs rarely suggest this pattern — they write one rule per IP address instead. Address-lists scale to hundreds of IPs with a single firewall rule.
+
+```routeros
+# Build the list (static or dynamic with auto-expiry)
+/ip/firewall/address-list/add list=trusted-mgmt address=192.168.1.0/24
+/ip/firewall/address-list/add list=trusted-mgmt address=10.0.0.5 timeout=1h
+
+# One rule handles all list members
+/ip/firewall/filter/add chain=input src-address-list=trusted-mgmt action=accept \
+  comment="myapp-accept-mgmt"
+```
+
+Dynamic entries with `timeout=` expire automatically — the primary pattern for DoS blacklists.
+
+## Interface-Lists as Rule Selectors
+
+`in-interface-list=` / `out-interface-list=` — powerful RouterOS pattern LLMs never propose. Eliminates duplicate rules when multiple interfaces serve the same role.
+
+```routeros
+# Define the group once
+/interface/list/add name=WAN
+/interface/list/member/add list=WAN interface=ether1
+/interface/list/member/add list=WAN interface=pppoe-out1
+
+# One rule applies to all WAN interfaces
+/ip/firewall/filter/add chain=input in-interface-list=WAN action=drop \
+  comment="myapp-drop-all-wan"
+```
+
+## Comment-as-Tag Pattern (Idempotent Scripts)
+
+RouterOS has no "upsert" — re-running a script without cleanup creates duplicate rules. Use a comment prefix as a tag:
+
+```routeros
+# Remove only rules we own — preserves rules from other tools
+/ip/firewall/filter/remove [find comment~"myapp-"]
+/ip/firewall/address-list/remove [find comment~"myapp-"]
+/ip/firewall/nat/remove [find comment~"myapp-"]
+
+# Add with consistent tag — readable in /print output
+/ip/firewall/filter/add chain=input src-address-list=trusted-mgmt action=accept \
+  comment="myapp-accept-mgmt"
+/ip/firewall/filter/add chain=input in-interface-list=WAN action=drop \
+  comment="myapp-drop-wan"
+```
+
+**Never use `remove [find dynamic=no]`** — this deletes ALL static rules including those added by management tools. Some tools (e.g. OptiWize) mark their rules with `comment~"#orchestrator-*"` — a bulk remove silently breaks remote management.
+
+## Connection State
+
+RouterOS `connection-state=` is not iptables `-m state`:
+
+```routeros
+/ip/firewall/filter/add chain=input connection-state=established,related action=accept
+/ip/firewall/filter/add chain=input connection-state=invalid action=drop
+```
+
+RouterOS states: `new`, `established`, `related`, `invalid`, `untracked`.
+
+`untracked` matches packets explicitly marked via `/ip/firewall/raw action=notrack` — it does NOT match FastTrack flows. FastTrack is a separate fast-path that keeps flows in conntrack but bypasses mangle. Never combine `fasttrack-connection` with mangle-based routing marks on the same traffic — mangle marks are not applied to fasttracked packets.
+
+## NAT Patterns
+
+```routeros
+# Port forward (dst-nat)
+/ip/firewall/nat/add chain=dstnat \
+  dst-port=8080 protocol=tcp in-interface=ether1 \
+  action=dst-nat to-addresses=192.168.1.10 to-ports=80 \
+  comment="portfwd-web"
+
+# Force DNS through router (prevents DNS bypass)
+/ip/firewall/nat/add chain=dstnat action=redirect \
+  dst-port=53 protocol=udp to-ports=53 comment="force-dns-udp"
+/ip/firewall/nat/add chain=dstnat action=redirect \
+  dst-port=53 protocol=tcp to-ports=53 comment="force-dns-tcp"
+
+# Masquerade outgoing traffic
+/ip/firewall/nat/add chain=srcnat action=masquerade \
+  out-interface=ether1 comment="nat-wan"
+```
+
+## Layer7 Protocol (L7)
+
+L7 matches unencrypted payload content with a POSIX regex — CPU-intensive, use sparingly:
+
+```routeros
+/ip/firewall/layer7-protocol/add \
+  name=captive-detect \
+  regexp="^.*(gstatic|connectivitycheck|generate_204).*$" \
+  comment="android-captive-portal"
+```
+
+L7 alternation: `(a|b|c)` is correct. `(a)|(b)|(c)` has POSIX ERE operator precedence bugs — the middle branch `(b)` matches anywhere in the stream, not anchored. Use grouped form with `|` inside parentheses only.
+
+## Common LLM Mistakes
+
+| Mistake | Correct RouterOS behavior |
+|---------|--------------------------|
+| Using `priority=` or rule weight | Rules are sequential — order is position, not weight |
+| Writing one rule per IP address | Use `src-address-list=` or `dst-address-list=` |
+| `remove [find dynamic=no]` in scripts | Tag-based: `remove [find comment~"prefix-"]` only |
+| Forgetting `place-before=` on accept rules | Default appends — accept rules below drops never fire |
+| `connection-state=new,established` | Valid states: `new`, `established`, `related`, `invalid`, `untracked` |
+| Combining fasttrack + mangle routing marks | fasttrack bypasses mangle — pick one or the other |
+| `(a)|(b)|(c)` alternation in L7 regexp | Use `(a|b|c)` — grouped form inside one set of parentheses |
+| One firewall rule per interface | Use `in-interface-list=` with a named interface list |
+| IPv6 traffic handled by `/ip/firewall` | IPv6 uses a **separate** `/ipv6/firewall` — rules do not apply cross-protocol |
+
+## Additional Resources
+
+**Related skills:**
+- `routeros-fundamentals` — RouterOS CLI syntax, REST API, scripting basics
+- `routeros-hotspot` — hotspot chain interaction with firewall, walled garden
+
+**Reference files in this skill:**
+- [references/mangle-routing.md](./references/mangle-routing.md) — policy routing with routing marks, `hotspot=auth` matcher
+- [references/dos-protection.md](./references/dos-protection.md) — `psd`, `tarpit`, `connection-limit` DoS patterns
+
+**MCP tools:**
+- `rosetta` MCP — `/ip/firewall` command tree inspection (`routeros_search`, `routeros_get_page`)
+
+**MikroTik docs:**
+- [Firewall Filter](https://help.mikrotik.com/docs/display/ROS/Filter) — filter chain reference
+- [NAT](https://help.mikrotik.com/docs/display/ROS/NAT) — NAT actions reference
+- [Connection tracking](https://help.mikrotik.com/docs/display/ROS/Connection+tracking) — connection states

--- a/routeros-firewall/SKILL.md
+++ b/routeros-firewall/SKILL.md
@@ -133,6 +133,7 @@ L7 alternation: `(a|b|c)` is correct. `(a)|(b)|(c)` has POSIX ERE operator prece
 | `remove [find dynamic=no]` in scripts | Tag-based: `remove [find comment~"prefix-"]` only |
 | Forgetting `place-before=` on accept rules | Default appends — accept rules below drops never fire |
 | `connection-state=new,established` | Valid states: `new`, `established`, `related`, `invalid`, `untracked` |
+| `action=log` or `passthrough=yes` stops evaluation | Non-terminal actions continue to next rule — a `drop` below still fires |
 | Combining fasttrack + mangle routing marks | fasttrack bypasses mangle — pick one or the other |
 | `(a)|(b)|(c)` alternation in L7 regexp | Use `(a|b|c)` — grouped form inside one set of parentheses |
 | One firewall rule per interface | Use `in-interface-list=` with a named interface list |

--- a/routeros-firewall/references/dos-protection.md
+++ b/routeros-firewall/references/dos-protection.md
@@ -1,0 +1,85 @@
+# DoS Protection Patterns
+
+RouterOS-specific DoS protection matchers. Referenced from `routeros-firewall` SKILL.md.
+
+## Port Scan Detection — `psd`
+
+`psd` is a RouterOS-specific TCP matcher that scores packets by destination port type:
+
+```routeros
+/ip/firewall/filter/add chain=input \
+  protocol=tcp psd=21,3s,3,1 \
+  action=add-src-to-address-list address-list=port-scanners \
+  address-list-timeout=1h comment="dos-detect-portscan"
+```
+
+**`psd=weight,delay,low-port-weight,high-port-weight` tuple:**
+- `weight` — total score threshold that triggers the rule (21 in example)
+- `delay` — max time between probe packets to count as one scan (3s)
+- `low-port-weight` — score added per probe of a port < 1024 (3 pts in example)
+- `high-port-weight` — score added per probe of a port ≥ 1024 (1 pt in example)
+
+**The last two values are weight scores, NOT port ranges.** Common mistake: treating them as `low-port,high-port` boundaries.
+
+Example: `psd=21,3s,3,1` — scanning 7 low ports (7×3=21) triggers the rule within 3 seconds.
+
+## `action=tarpit`
+
+TCP tarpit — completes the handshake but stalls the connection indefinitely:
+
+```routeros
+/ip/firewall/filter/add chain=input \
+  src-address-list=dos-attackers \
+  connection-limit=3,32 protocol=tcp \
+  action=tarpit comment="dos-tarpit-blacklist"
+```
+
+**How it works:** Completes SYN/SYN-ACK/ACK, then advertises a TCP receive window size of **zero**. The sender cannot transmit data (zero window = no send permission) and the connection stalls in ESTABLISHED state indefinitely, consuming attacker resources.
+
+- TCP only (`protocol=tcp` required)
+- Does NOT throttle bandwidth — data never flows at all
+- Effective against connection-flood attacks where cost is per-connection
+
+## `connection-limit` Tuple
+
+```routeros
+/ip/firewall/filter/add chain=input \
+  protocol=tcp connection-state=new connection-limit=100,32 \
+  action=add-src-to-address-list address-list=dos-attackers \
+  address-list-timeout=1h comment="dos-detect-ddos"
+```
+
+**`connection-limit=X,Y` tuple:**
+- `X` — maximum simultaneous connections
+- `Y` — netmask prefix bits (32 = per individual IP, 24 = per /24 subnet)
+
+`connection-limit=100,32` = max 100 simultaneous connections per individual IP.
+
+Add `connection-state=new` guard — limits evaluation to new connections only, reducing router CPU load under the attack conditions the rule is meant to detect.
+
+## Combined Blacklist Pattern
+
+Three-stage pattern: detect → blacklist → tarpit:
+
+```routeros
+# Stage 1: detect port scanners
+/ip/firewall/filter/add chain=input \
+  protocol=tcp psd=21,3s,3,1 \
+  action=add-src-to-address-list address-list=port-scanners \
+  address-list-timeout=1h comment="dos-detect-portscan"
+
+# Stage 2: detect connection floods
+/ip/firewall/filter/add chain=input \
+  protocol=tcp connection-state=new connection-limit=100,32 \
+  action=add-src-to-address-list address-list=dos-attackers \
+  address-list-timeout=1h comment="dos-detect-ddos"
+
+# Stage 3: tarpit blacklisted sources (connection-limit=3,32 is the second gate)
+/ip/firewall/filter/add chain=input \
+  src-address-list=dos-attackers connection-limit=3,32 protocol=tcp \
+  action=tarpit comment="dos-tarpit-blacklist"
+```
+
+Note: the tarpit rule also requires `connection-limit=3,32` — blacklisted IPs with fewer than 3 simultaneous connections are not tarpitted by this pattern.
+
+The `address-list-timeout=1h` on detection rules means entries auto-expire — no manual cleanup needed.

--- a/routeros-firewall/references/mangle-routing.md
+++ b/routeros-firewall/references/mangle-routing.md
@@ -1,0 +1,114 @@
+# Mangle and Policy Routing
+
+RouterOS mangle chains and routing marks for policy-based routing. Referenced from `routeros-firewall` SKILL.md.
+
+## Routing Tables
+
+Policy routing requires a dedicated routing table. In RouterOS v7:
+
+```routeros
+# Create the routing table (fib = Forward Information Base, required)
+/routing/table/add name=vpn-mark fib
+```
+
+The `fib` keyword is required — it pushes resolved routes to the kernel FIB.
+
+## mark-routing in Mangle Prerouting
+
+Mark packets in `prerouting` to assign them to an alternate routing table:
+
+```routeros
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 \
+  action=mark-routing new-routing-mark=vpn-mark passthrough=yes \
+  comment="mypolicy-mark-clients"
+```
+
+`passthrough=yes` — evaluation continues to the next mangle rule after marking.
+
+The marked routing table applies when RouterOS makes the routing decision for the packet.
+
+## Exempt DNS from Policy Routing
+
+DNS must reach the local router, not the alternate gateway. Add the DNS exemption rule **before** the mark-routing rule:
+
+```routeros
+# DNS exempt — MUST be before the mark-routing rule
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 protocol=udp port=53 \
+  action=accept comment="mypolicy-exempt-dns"
+
+# Mark remaining traffic
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 \
+  action=mark-routing new-routing-mark=vpn-mark passthrough=yes \
+  comment="mypolicy-mark-clients"
+```
+
+Rule order is critical — DNS exempt must come first (see SKILL.md Rule Ordering section).
+
+## `hotspot=auth` Matcher
+
+RouterOS hotspot adds a `hotspot=` property to mangle — matches only packets from authenticated hotspot clients:
+
+```routeros
+# Only route AUTHENTICATED hotspot clients through the alternate gateway
+# Unauthenticated clients (pre-login) are not affected
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 hotspot=auth \
+  action=mark-routing new-routing-mark=vpn-mark passthrough=yes \
+  comment="mypolicy-mark-authed"
+```
+
+Valid `hotspot=` values: `auth` (authenticated clients), `from-client`, `local-dst`, `http`.
+
+## Generic Policy Routing Pattern
+
+Complete minimal pattern — route traffic from one subnet through an alternate gateway:
+
+```routeros
+# 1. Routing table
+/routing/table/add name=vpn-mark fib
+
+# 2. DNS exempt (before mark rule)
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 protocol=udp port=53 \
+  action=accept comment="mypolicy-exempt-dns-udp"
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 protocol=tcp port=53 \
+  action=accept comment="mypolicy-exempt-dns-tcp"
+
+# 3. Mark traffic (authenticated hotspot clients only)
+/ip/firewall/mangle/add chain=prerouting \
+  src-address=10.20.0.0/24 hotspot=auth \
+  action=mark-routing new-routing-mark=vpn-mark passthrough=yes \
+  comment="mypolicy-mark"
+
+# 4. NAT for alternate gateway outbound
+/ip/firewall/nat/add chain=srcnat action=masquerade \
+  out-interface=my-gateway-interface place-before=0 \
+  comment="mypolicy-nat"
+
+# 5. Route (start DISABLED — enable after gateway interface is up)
+/ip/route/add dst-address=0.0.0.0/0 gateway=my-gateway-interface \
+  routing-table=vpn-mark distance=1 disabled=yes
+
+# Enable after gateway is configured:
+# /ip/route/set enabled=yes [find routing-table=vpn-mark]
+```
+
+## MSS Clamping
+
+VPN interfaces often have a lower MTU than the WAN interface. Clamp TCP MSS to prevent fragmentation:
+
+```routeros
+/ip/firewall/mangle/add chain=forward \
+  action=change-mss new-mss=1360 \
+  protocol=tcp tcp-flags=syn out-interface=my-gateway-interface \
+  place-before=0 passthrough=yes \
+  comment="mypolicy-mss-clamp"
+```
+
+## FastTrack Interaction
+
+FastTrack bypasses mangle entirely for fast-pathed flows. If a connection is fasttracked, mangle rules (including `mark-routing`) are not applied. Do not combine `fasttrack-connection` with mangle-based policy routing on the same traffic.


### PR DESCRIPTION
## Summary

- Adds `routeros-firewall` skill covering RouterOS v7 firewall configuration
- Covers: rule ordering (sequential + non-terminal action exceptions), address-lists and interface-lists as selectors, comment-as-tag idempotent scripting, connection-state (untracked vs FastTrack), NAT patterns, L7 alternation syntax, IPv6 separate firewall note
- Includes `references/mangle-routing.md` — routing tables, mark-routing, DNS exempt order, `hotspot=auth` matcher, generic policy routing pattern, MSS clamping, FastTrack interaction
- Includes `references/dos-protection.md` — `psd` tuple (weight scores not port ranges), `action=tarpit` (TCP window=0 mechanics), `connection-limit` tuple, combined detect/blacklist/tarpit pattern

## Grounded from

- Production RouterOS scripts ([CloudWiFi](https://cloudwifi.de/?lang=en) hotspot, ~3000 devices, RouterOS 7.x)

## Test plan

- [ ] SKILL.md frontmatter YAML valid
- [ ] All 8 content sections present + Additional Resources
- [ ] Both reference files resolve from relative links
- [ ] `hotspot=auth` documented as real RouterOS property with correct values