### PR TITLE
docs(security): correct CodeQL posture to match Default Setup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,14 +19,14 @@ So the practical security surface is the **CI workflows** and the **dev dependen
 
 The repository's [Security tab](https://github.com/tikoci/routeros-skills/security) is the live source of current alerts and advisories. This section describes *what* checks run and *why*, so it stays meaningful even when the badge is at 0.
 
-- **CodeQL** — GitHub [Default Setup](https://github.com/tikoci/routeros-skills/settings/security_analysis), `extended` query suite (security-extended). Languages: `javascript-typescript` (the Bun helper) and `actions` (the workflow YAML — the higher-value target here). Runs on push to `main` and pull requests. Default Setup is used because the org auto-enables it on public repos; an advanced repo-managed workflow would conflict with it.
+- **CodeQL** — GitHub [Default Setup](https://github.com/tikoci/routeros-skills/settings/security_analysis), `default` query suite (the org-managed baseline). Language: `javascript-typescript` (the Bun helper script). Runs on push to `main` and pull requests. Default Setup is used because the org auto-enables it on public repos; an advanced repo-managed workflow (which could also scan the `actions` workflow YAML) would conflict with it.
 - **Code Quality (AI findings, preview)** — not enabled.
 - **Dependency review** — [`.github/workflows/dependency-review.yml`](.github/workflows/dependency-review.yml), `fail-on-severity: high`, on pull requests.
 - **Dependabot alerts** — enabled.
 - **Secret scanning** — enabled (GitHub default for public repositories), with push protection.
 - **Private vulnerability reporting** — enabled.
 
-Because there is so little code, CodeQL is intentionally low-volume; it is kept mostly for the `actions` analysis and to stay on the tikoci public-repo baseline.
+Because there is so little code (one Bun helper script), CodeQL is intentionally low-volume; it is kept to stay on the tikoci public-repo baseline.
 
 ## Supported versions
 


### PR DESCRIPTION
Small follow-up to #7. The org-managed CodeQL **Default Setup** runs the `default` query suite on `javascript-typescript` only — a per-repo override to `extended`, and adding the `actions` language, don't stick under the org policy. This aligns `SECURITY.md` with what's actually configured (the `tikoci-security-md` skill requires the suite name to be accurate).

Also doubles as the first routine doc PR through the new PR → main gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)