### PR TITLE
chore(ci,docs): pin Actions to SHA; clarify Skill Set vs CI/QA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+# Keep the SHA-pinned third-party Actions in .github/workflows/** fresh.
+# Without this, pinning to a commit SHA (required by the CodeQL
+# actions/unpinned-tag rule) would silently freeze versions forever.
+# Dependabot bumps the SHA and updates the trailing `# vX.Y.Z` comment.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
       - name: markdownlint + cspell + skill validator
         run: bun run check
@@ -46,7 +46,7 @@ jobs:
       # rate-limited host never fails the gate. (External-URL checking can be
       # added later as a separate, non-blocking scheduled workflow.)
       - name: Link & anchor check (offline)
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           # --exclude-path node_modules is belt-and-suspenders: this job does a
           # bare checkout (no `bun install`), so node_modules shouldn't exist —
@@ -60,4 +60,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Lint workflow YAML
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -11,6 +11,12 @@
 ignores:
   - "node_modules/**"
   - "**/node_modules/**"
+  # Git internals: remote-tracking ref/log files inherit the branch name, and
+  # the AI-findings autofix bot names branches after the file they touch
+  # (e.g. ai-findings-autofix/...-SKILL.md), so `.git/**` can contain paths
+  # ending in `.md`. Fresh CI checkouts don't have these refs, but a local
+  # `make lint` after fetching them would otherwise fail on git internals.
+  - ".git/**"
   # LLM instruction files — different audience, intentionally loose structure.
   # None live in this repo today; listed defensively in case one is added.
   - "CLAUDE.md"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ This repo is the **single source of truth** for all `routeros-*` skills. Locally
 
 Non-`routeros-*` skills (e.g. `tikoci-*`, `screenshot`, `sql-as-rag`) are personal/project-scoped and live only in the local `~/.*/skills/` directories, **not** in this repo. See [SETUP.md](SETUP.md) for the full local setup guide.
 
+**The Skill Set is the `routeros-*/` folders only.** Everything else at the repo root is the **CI/QA and tooling layer** that validates and ships those skills — it is *not* part of the skill content and is not symlinked into `~/.*/skills/`:
+
+- `.github/` — CI workflows (lint, link check, dependency review), CodeQL Default Setup, and Dependabot config
+- `scripts/` — the `SKILL.md` validator (`check-skills.ts`) run by CI and `make lint`
+- `hooks/` — optional local git hooks that re-symlink skills after checkout/merge (`make install-hooks`)
+- `Makefile`, `.markdownlint*.yaml`, `cspell.json`, `project-words.txt`, `package.json`, `bun.lock` — lint/build configuration and the dev dependency tree
+
 ## Scope
 
 These skills cover **RouterOS 7.x** (long-term and newer releases). RouterOS v6 is not covered and accuracy for v6 questions will be low.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,8 +19,8 @@ So the practical security surface is the **CI workflows** and the **dev dependen
 
 The repository's [Security tab](https://github.com/tikoci/routeros-skills/security) is the live source of current alerts and advisories. This section describes *what* checks run and *why*, so it stays meaningful even when the badge is at 0.
 
-- **CodeQL** — GitHub [Default Setup](https://github.com/tikoci/routeros-skills/settings/security_analysis), `default` query suite (the org-managed baseline). Language: `javascript-typescript` (the Bun helper script). Runs on push to `main` and pull requests. Default Setup is used because the org auto-enables it on public repos; an advanced repo-managed workflow (which could also scan the `actions` workflow YAML) would conflict with it.
-- **Code Quality (AI findings, preview)** — not enabled.
+- **CodeQL** — GitHub [Default Setup](https://github.com/tikoci/routeros-skills/settings/security_analysis), `default` query suite (the org-managed baseline). Languages: `javascript-typescript` (the Bun helper script) and `actions` (the workflow YAML — this is what raises the `actions/unpinned-tag` advice, so third-party Actions in [`.github/workflows/**`](.github/workflows) are pinned to a commit SHA with a `# vX.Y.Z` comment and kept fresh by Dependabot). Runs on push to `main` and pull requests. Default Setup is used because the org auto-enables it on public repos; an advanced repo-managed workflow would conflict with it.
+- **Code Quality (AI findings, preview)** — enabled. Surfaces non-security code-quality suggestions for the Bun script and Markdown prose; GitHub can open autofix PRs for them (labeled `gh-ai-finding`). These are advisory, not a merge gate.
 - **Dependency review** — [`.github/workflows/dependency-review.yml`](.github/workflows/dependency-review.yml), `fail-on-severity: high`, on pull requests.
 - **Dependabot alerts** — enabled.
 - **Secret scanning** — enabled (GitHub default for public repositories), with push protection.


### PR DESCRIPTION
## What

Repo hygiene from reviewing the code-scanning alerts and AI findings.

### Fixes the 3 `actions/unpinned-tag` code-scanning alerts
Pins the third-party Actions in `ci.yml` to commit SHAs (with `# vX.Y.Z` comments):

| Action | Pin |
|--------|-----|
| `oven-sh/setup-bun` | `0c5077e…857d6` # v2.2.0 |
| `lycheeverse/lychee-action` | `8646ba3…b411` # v2.8.0 |
| `raven-actions/actionlint` | `205b530…a6f8` # v2.1.2 |

`actions/checkout` is left on a tag — CodeQL trusts the first-party `actions/*` org and does not flag it.

Adds `.github/dependabot.yml` (github-actions, weekly) so the SHA pins don't silently freeze.

### Docs alignment
- **README** — new note under *Repository layout*: the Skill Set is the `routeros-*/` folders only; `.github/`, `scripts/`, `hooks/`, `Makefile`, and lint configs are the CI/QA & tooling layer (not skills, not symlinked).
- **SECURITY.md** — CodeQL Default Setup also scans the `actions` language (source of these alerts); the Code Quality "AI findings" preview is **enabled** (it opened #9–#11), not disabled.

### Lint robustness
- **`.markdownlint-cli2.yaml`** — ignore `.git/**`. The AI-findings autofix bot names branches `…-SKILL.md`, so remote-tracking ref files (`.git/refs/.../…-SKILL.md`) were caught by the `**/*.md` glob and broke `make lint` locally after fetching those branches. CI dodged it only because fresh checkouts lack the refs.

## Verification
`make lint` → markdownlint 0 errors · cspell 0 issues · `✓ 13 skills valid`. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)