### PR TITLE
docs(contributing): don't record unverified or CI-only findings in a skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ every agent that loads these skills, so we gate quality in CI.
 [CodeRabbit]: https://coderabbit.ai/
 [GitHub Copilot]: https://github.com/features/copilot
 
+## Grounding: don't record what you haven't verified
+
+A skill ships to every agent on every project — a wrong "fact" here propagates far. So
+the bar for what gets written down is higher than "it seemed true once":
+
+- **A single CI failure (or one log line) is not grounding — it's a lead.** Reproduce the
+  behavior locally before describing it as how RouterOS, QEMU, or a tool "works."
+- **Don't record a suspected platform/tool limitation you haven't reproduced.** Claims
+  like "snapshots don't work on arm64" or "X is unsupported on Y" must be *demonstrated*
+  (a local run, a `/console/inspect` query, an anchor test, a `mikrotik.com` docs URL) —
+  a plausible mechanism remembered from training data is not evidence.
+- **Less detail beats shaky detail.** If you can't ground a claim, omit it rather than
+  state a guess as fact. This is the footnote-grounding discipline the review bots
+  enforce; help them by not writing the guess in the first place.
+
 ## Running the checks locally
 
 Prerequisites: [Bun](https://bun.sh). Optional: [lychee](https://lychee.cli.rs/)


### PR DESCRIPTION
## Why

A skill ships to every agent on every project — a wrong "fact" recorded here propagates everywhere downstream. This adds an explicit grounding rule to `CONTRIBUTING.md` for the *content* bar (the linters can only catch structure/spelling).

Prompted by a real near-miss in `tikoci/quickchr`: a **single** Extended Verification run was about to be written down as a fundamental "QEMU snapshots don't work on arm64" limitation — and propagated into the shared `routeros-qemu-chr` skill — with **no local reproduction**, despite arm64 CHR being runnable under TCG locally.

## Change

New `## Grounding: don't record what you haven't verified` section:
- A single CI failure (or one log line) is a **lead, not grounding** — reproduce locally first.
- Don't record a suspected platform/tool limitation you haven't reproduced; demonstrate it (local run, `/console/inspect`, anchor test, `mikrotik.com` docs) — a remembered training-data prior is not evidence.
- **Less detail beats shaky detail** — omit an unground-able claim rather than state a guess as fact. (Reinforces the existing footnote-grounding discipline the review bots enforce.)

`make lint` and `make lint-links` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)