### PR TITLE
feat: routeros-syntax-inspection skill + Codex skill dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,32 @@
 # routeros-skills — symlink management for AI assistant skill dirs.
 #
 # Each routeros-*/ dir in this repo must be symlinked into BOTH
-# ~/.copilot/skills/ and ~/.claude/skills/ or the assistant won't load it.
+# ~/.copilot/skills/, ~/.claude/skills/, and ~/.agents/skills/ or the
+# assistant won't load it.
 # (A symlinked skill is still only picked up on a fresh assistant session.)
 #
-#   make link    # idempotently symlink every routeros-* into both dirs
-#   make check   # report any repo skill missing from either dir (non-zero exit)
-#   make unlink   # remove this repo's routeros-* symlinks from both dirs
+#   make link    # idempotently symlink every routeros-* into every target dir
+#   make check   # report any missing/wrong/non-symlink target (non-zero exit)
+#   make unlink   # remove this repo's routeros-* symlinks from every target dir
 #   make install-hooks  # run `make link` automatically after pull/checkout
 #   make lint    # run the same lint gate as CI (markdownlint + cspell + skill validator)
 
 REPO    := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-SKILLS  := $(notdir $(wildcard $(REPO)/routeros-*))
-TARGETS := $(HOME)/.copilot/skills $(HOME)/.claude/skills
+LINKER  := $(REPO)/scripts/link-skills.sh
 
-.PHONY: link unlink check install-hooks lint
+.PHONY: link unlink check targets install-hooks lint
 
 link:
-	@for t in $(TARGETS); do \
-	  mkdir -p "$$t"; \
-	  for s in $(SKILLS); do \
-	    if [ ! -e "$$t/$$s" ]; then \
-	      ln -s "$(REPO)/$$s" "$$t/$$s" && echo "linked  $$t/$$s"; \
-	    fi; \
-	  done; \
-	done; \
-	echo "link: done"
+	@$(LINKER) link
 
 unlink:
-	@for t in $(TARGETS); do \
-	  for s in $(SKILLS); do \
-	    if [ -L "$$t/$$s" ]; then rm "$$t/$$s" && echo "removed $$t/$$s"; fi; \
-	  done; \
-	done; \
-	echo "unlink: done"
+	@$(LINKER) unlink
 
 check:
-	@rc=0; \
-	for s in $(SKILLS); do \
-	  if [ ! -f "$(REPO)/$$s/SKILL.md" ]; then echo "NO SKILL.md: $$s"; rc=1; fi; \
-	  for t in $(TARGETS); do \
-	    if [ ! -e "$$t/$$s" ]; then echo "MISSING:  $$t/$$s"; rc=1; fi; \
-	  done; \
-	done; \
-	if [ $$rc -eq 0 ]; then echo "check: all $(words $(SKILLS)) skills linked into both dirs"; fi; \
-	exit $$rc
+	@$(LINKER) check
+
+targets:
+	@$(LINKER) targets
 
 install-hooks:
 	@chmod +x "$(REPO)/hooks/"* 2>/dev/null || true; \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/tikoci/routeros-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/tikoci/routeros-skills/actions/workflows/ci.yml)
 
-Custom instruction skills for [GitHub Copilot](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot) and Claude Code (and similar AI coding assistants) that teach them about [MikroTik RouterOS](https://mikrotik.com/) v7.
+Custom instruction skills for [GitHub Copilot](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot), Claude Code, Codex, and similar AI coding assistants that teach them about [MikroTik RouterOS](https://mikrotik.com/) v7.
 
 ## Skills
 
@@ -24,31 +24,26 @@ Custom instruction skills for [GitHub Copilot](https://docs.github.com/en/copilo
 
 ## Install
 
-Clone this repo and symlink the skill folders into `~/.copilot/skills/` (and/or `~/.claude/skills/`):
+Clone this repo and symlink the skill folders into your assistant skill directories:
 
 ```sh
 git clone https://github.com/tikoci/routeros-skills.git ~/GitHub/routeros-skills
 
-# Symlink all routeros-* skills at once (Copilot)
-for skill in ~/GitHub/routeros-skills/routeros-*/; do
-  ln -s "$skill" ~/.copilot/skills/"$(basename $skill)"
-done
-
-# Same for Claude
-for skill in ~/GitHub/routeros-skills/routeros-*/; do
-  ln -s "$skill" ~/.claude/skills/"$(basename $skill)"
-done
+cd ~/GitHub/routeros-skills
+make link   # Copilot, Claude, and Codex
+make check
 ```
 
 Each skill is a folder containing a `SKILL.md` file and optionally a `references/` subfolder. VS Code Copilot and Claude Code automatically discover skills in their respective `~/.*/skills/` directories.
+Codex discovers user-authored skills in `~/.agents/skills`.
 
 > **Tip:** Start with **routeros-fundamentals** — it covers the core concepts that other skills reference.
 
 ## Repository layout
 
-This repo is the **single source of truth** for all `routeros-*` skills. Locally, `~/.copilot/skills/routeros-*` and `~/.claude/skills/routeros-*` are symlinks into this repo — editing either location is the same as editing here.
+This repo is the **single source of truth** for all `routeros-*` skills. Locally, `~/.copilot/skills/routeros-*`, `~/.claude/skills/routeros-*`, and `~/.agents/skills/routeros-*` are symlinks into this repo — editing any of those locations is the same as editing here.
 
-Non-`routeros-*` skills (e.g. `tikoci-*`, `screenshot`, `sql-as-rag`) are personal/project-scoped and live only in the local `~/.*/skills/` directories, **not** in this repo. See [SETUP.md](SETUP.md) for the full local setup guide.
+Non-`routeros-*` skills (e.g. `tikoci-*`, `screenshot`, `sql-as-rag`) are personal/project-scoped and live only in the local user-level skill directories, **not** in this repo. See [SETUP.md](SETUP.md) for the full local setup guide.
 
 **The Skill Set is the `routeros-*/` folders only.** Everything else at the repo root is the **CI/QA and tooling layer** that validates and ships those skills — it is *not* part of the skill content and is not symlinked into `~/.*/skills/`:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Custom instruction skills for [GitHub Copilot](https://docs.github.com/en/copilo
 | **routeros-hotspot** | RouterOS hotspot captive portal for wired/wireless access control — hotspot chains, profiles, walled garden, DHCP option 114 (RFC 8910), RADIUS integration. |
 | **routeros-app-yaml** | RouterOS `/app` YAML format for container applications (7.21+ builtin, 7.22+ custom YAML). |
 | **routeros-command-tree** | `/console/inspect` API — command tree introspection, schema generation, CLI-to-REST mapping. |
+| **routeros-syntax-inspection** | `/console/inspect` syntax surfaces (`highlight`/`completion`/`syntax`) + `:parse` IL — validating commands, reading token streams, enum discovery, script "explain"/lint; necessary-not-sufficient vs runtime. |
 | **routeros-qemu-chr** | MikroTik CHR (Cloud Hosted Router) with QEMU — boot, VirtIO, acceleration, CI/CD patterns. |
 | **routeros-quickchr** | Ground RouterOS config/scripts/API code against a real router with quickchr (`@tikoci/quickchr`) — boot a disposable CHR, apply config, read it back; networking recipes, integration-test harness patterns. |
 | **routeros-netinstall** | `netinstall-cli` for automated RouterOS device flashing — etherboot, BOOTP/TFTP, modescript. |

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,8 +9,14 @@ This document describes how the skill directories are organized locally. It is *
 | `~/GitHub/routeros-skills/` | **Source of truth** for all `routeros-*` skills. This is the tikoci/routeros-skills Git repo. |
 | `~/.copilot/skills/routeros-*` | Symlinks → `~/GitHub/routeros-skills/routeros-*` |
 | `~/.claude/skills/routeros-*` | Symlinks → `~/GitHub/routeros-skills/routeros-*` |
+| `~/.agents/skills/routeros-*` | Symlinks → `~/GitHub/routeros-skills/routeros-*` for Codex |
 | `~/.copilot/skills/<non-routeros>` | Real dirs or symlinks to `~/.claude/skills/` — local-only, not in this repo |
 | `~/.claude/skills/<non-routeros>` | Real dirs — local-only, not in this repo |
+| `~/.agents/skills/<non-routeros>` | Real dirs or symlinks — local-only, not in this repo |
+
+Codex reads user-authored skills from `~/.agents/skills`. `~/.codex/skills`
+contains Codex-managed/system skills and is not the right target for these
+repo-owned `routeros-*` symlinks.
 
 ## Rule: what belongs in this repo
 
@@ -21,17 +27,9 @@ This document describes how the skill directories are organized locally. It is *
 ```sh
 git clone https://github.com/tikoci/routeros-skills.git ~/GitHub/routeros-skills
 
-mkdir -p ~/.copilot/skills ~/.claude/skills
-
-# Symlink all routeros-* skills for Copilot
-for skill in ~/GitHub/routeros-skills/routeros-*/; do
-  ln -sf "$skill" ~/.copilot/skills/"$(basename $skill)"
-done
-
-# Symlink all routeros-* skills for Claude
-for skill in ~/GitHub/routeros-skills/routeros-*/; do
-  ln -sf "$skill" ~/.claude/skills/"$(basename $skill)"
-done
+cd ~/GitHub/routeros-skills
+make link   # symlink every routeros-* into Copilot, Claude, and Codex dirs
+make check  # verify every repo skill is a symlink in all three dirs
 ```
 
 ## Updating
@@ -64,14 +62,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for what each check does and the spelling
 skill=routeros-<name>
 ln -s ~/GitHub/routeros-skills/$skill ~/.copilot/skills/$skill
 ln -s ~/GitHub/routeros-skills/$skill ~/.claude/skills/$skill
+ln -s ~/GitHub/routeros-skills/$skill ~/.agents/skills/$skill
 ```
 
-   Or, idempotently link **all** skills into both dirs (preferred — avoids the
+   Or, idempotently link **all** skills into all target dirs (preferred — avoids the
    "committed but never symlinked" drift):
 
 ```sh
-make link    # symlink every routeros-* into ~/.copilot/skills and ~/.claude/skills
-make check   # verify every repo skill is linked into both dirs (non-zero exit if not)
+make link    # symlink every routeros-* into Copilot, Claude, and Codex dirs
+make check   # verify every repo skill is linked into all target dirs (non-zero exit if not)
 ```
 
    Note: a symlinked skill is only picked up on a **fresh** assistant session.
@@ -80,7 +79,9 @@ make check   # verify every repo skill is linked into both dirs (non-zero exit i
 
 ## Current symlink state (reference)
 
-After setup, `ls -la ~/.copilot/skills/` should show all `routeros-*` entries as symlinks pointing to `~/GitHub/routeros-skills/routeros-*`, for example:
+After setup, `ls -la ~/.copilot/skills/`, `ls -la ~/.claude/skills/`, and
+`ls -la ~/.agents/skills/` should show all `routeros-*` entries as symlinks
+pointing to `~/GitHub/routeros-skills/routeros-*`, for example:
 
 ```text
 lrwxr-xr-x  routeros-fundamentals -> /Users/<you>/GitHub/routeros-skills/routeros-fundamentals

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,5 +1,5 @@
 #!/bin/sh
 # Re-link skills after `git checkout`/clone so newly-present routeros-* dirs are
-# symlinked into ~/.copilot/skills and ~/.claude/skills. Idempotent.
+# symlinked into all configured user-level assistant skill dirs. Idempotent.
 # Enable with: make install-hooks
 exec make -C "$(git rev-parse --show-toplevel)" link

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/bin/sh
 # Re-link skills after `git pull`/merge so newly-added routeros-* dirs are
-# symlinked into ~/.copilot/skills and ~/.claude/skills. Idempotent.
+# symlinked into all configured user-level assistant skill dirs. Idempotent.
 # Enable with: make install-hooks
 exec make -C "$(git rev-parse --show-toplevel)" link

--- a/project-words.txt
+++ b/project-words.txt
@@ -16,6 +16,7 @@ backgrounding
 BASICAUTH
 BEGINAUTH
 BFD
+blackhole
 BLE
 BOOTX
 browsable
@@ -51,6 +52,7 @@ datapath
 DECID
 defconf
 descr
+desynchronize
 dgram
 dont
 dport
@@ -76,6 +78,7 @@ FDB
 fdisk
 FHS
 figcaption
+findwhere
 flogin
 flogout
 footgun
@@ -105,6 +108,7 @@ iface
 ifaces
 INSPECTFILE
 ipc
+iscsi
 kbd
 keepalive
 Keepalives
@@ -116,6 +120,7 @@ LLDP
 LLM
 LLM's
 loadvm
+localname
 lrwxr
 lsbridge
 lsp
@@ -169,6 +174,7 @@ NIC
 nlevel
 nofile
 nohup
+nonorm
 notrack
 nowait
 npk
@@ -181,6 +187,7 @@ Opti
 OSPF
 OVMF
 paravirt
+parseil
 PASSSALT
 pathed
 PCC
@@ -207,6 +214,7 @@ PRL
 proplist
 PTR
 ptype
+putmessage
 pvid
 QCOW
 QGA
@@ -220,6 +228,7 @@ recvfrom
 redirector
 Referer
 replayable
+requiredness
 restraml
 REUSEADDR
 REUSEPORT
@@ -256,6 +265,7 @@ SRP
 sshpass
 SSTP
 standardly
+statefulness
 strsep
 subarray
 subshell
@@ -296,6 +306,7 @@ usermanager
 userscript
 userspace
 usr
+varname
 vdi
 ver
 VETH

--- a/routeros-command-tree/SKILL.md
+++ b/routeros-command-tree/SKILL.md
@@ -69,8 +69,8 @@ Requires basic authentication. Available on all RouterOS 7.x versions.
 |---|---|---|
 | `child` | List children of a path | Array of `{type: "child", name, "node-type"}` |
 | `syntax` | Get help text for a node | Array of `{type: "syntax", text}` |
-| `highlight` | Syntax highlighting data | Tokenized output (rarely used) |
-| `completion` | Tab-completion suggestions | Completion candidates |
+| `highlight` | Syntax highlighting data | Per-byte token classes — see the `routeros-syntax-inspection` skill |
+| `completion` | Tab-completion suggestions | Completion candidates — see `routeros-syntax-inspection` for validity checking |
 
 ### Listing Children
 
@@ -159,22 +159,29 @@ async function walkTree(path = [], tree = {}) {
 }
 ```
 
-### Dangerous Paths — Must Skip
+### Dangerous Paths — Conservative Skip Policy
 
-These path segments **crash the RouterOS REST server** when their `arg` nodes are queried
-for syntax via `/console/inspect`. Always skip syntax lookups for args inside subtrees
-containing any of these names:
+Old RouterOS versions can **deadlock the REST server** when scripting-keyword paths are
+queried for syntax/completion via `/console/inspect`. Crawlers conservatively skip
+syntax lookups inside subtrees containing any of these names:
 
 ```text
 where, do, else, rule, command, on-error
 ```
 
-These are RouterOS scripting constructs. Specifically, **`fetchSyntax()` on `arg` node-types**
-within these subtrees terminates the HTTP server process. Enumerating children (`child` request)
-is safe even inside these paths — only the syntax/description lookup for arguments crashes.
+These are RouterOS scripting constructs. Treat the six-path list as a **conservative
+crawler skip policy, not a timeless crash invariant**: live probing in
+[tikoci/restraml](https://github.com/tikoci/restraml) (MikroTik support case SUP-127641)
+isolated the confirmed deadlock to bare `do` with `request=syntax`/`completion` on
+RouterOS ≤7.20.8 — the other five paths return `[]` instantly there — and found it
+**fixed by 7.21.4**. (The original six-path folklore came from sequential probing: once
+`do` hangs the server, every path tested after it appears to crash too.) Enumerating
+children (`child` request) is safe on all tested versions, as are nested paths like
+`["do","command"]`.
 
-The conservative approach (used in the example above) skips the entire arg when any ancestor
-matches a dangerous path. The actual `rest2raml.js` implementation matches this pattern.
+The conservative approach (used in the example above) skips the entire arg when any
+ancestor matches a dangerous path, and pairs every request with a short timeout on old
+or unknown versions. The actual `rest2raml.js` implementation matches this pattern.
 
 ```typescript
 const DANGEROUS_PATHS = ["where", "do", "else", "rule", "command", "on-error"];

--- a/routeros-quickchr/SKILL.md
+++ b/routeros-quickchr/SKILL.md
@@ -43,7 +43,10 @@ await chr.remove();   // tear down
 `rest()` does a REST call and returns parsed JSON. Worked, runnable version:
 [`examples/grounding/`](https://github.com/tikoci/quickchr/tree/main/examples/grounding).
 Minimal boot-and-read smoke test:
-[`examples/vienk/`](https://github.com/tikoci/quickchr/tree/main/examples/vienk).
+[`examples/quickstart/`](https://github.com/tikoci/quickchr/tree/main/examples/quickstart).
+All examples are runnable `bun run` scripts (`grounding/` is the one `bun:test`); the
+full set + coverage map is in
+[`examples/COVERAGE.md`](https://github.com/tikoci/quickchr/tree/main/examples/COVERAGE.md).
 
 > **Tip — re-run safety.** Give each run a unique machine name and assert on
 > values carrying a per-run nonce, so a stale machine from an interrupted run can't

--- a/routeros-syntax-inspection/SKILL.md
+++ b/routeros-syntax-inspection/SKILL.md
@@ -58,9 +58,12 @@ share nothing — treat them as four APIs behind one endpoint.
 
 ## Version baseline and safety
 
-- **Baseline: RouterOS 7.20.8** (the first v7 long-term release). REST itself
-  exists since 7.1beta4 (HTTPS-only at first [^2]); behavior below 7.20.8 is
-  best-effort, and RouterOS v6 has no REST API at all.
+- **Baseline: RouterOS 7.20.8** — a long-term-channel release, used here as the
+  recommended floor: the parseIL and crash-path behavior below was captured on
+  it [^1][^3]. REST itself exists since 7.1beta4 (HTTPS-only at first [^2]);
+  behavior below 7.20.8 is best-effort (7.9.2 was measured but harsher — see
+  [references/highlight.md](references/highlight.md)), and RouterOS v6 has no
+  REST API at all.
 - **Always set a per-request timeout** (a few seconds). Old versions can hang
   the whole REST server on specific inspect calls; a hung server also makes
   *subsequent* unrelated probes appear broken.
@@ -70,7 +73,7 @@ share nothing — treat them as four APIs behind one endpoint.
 |---|---|---|
 | `request=syntax`/`completion` at bare path `do` deadlocks the REST server | ≤ 7.20.8 (fixed by 7.21.4) [^3] | Skip scripting-keyword paths (`where`, `do`, `else`, `rule`, `command`, `on-error`) on old/unknown versions; it is a conservative skip policy, not a timeless six-path crash rule |
 | `request=syntax` with `input`, or command-level `syntax`, stalls ~60 s | observed on 7.9.2 | Query `syntax` by `path` only; feature-detect command-level lookups with a short timeout |
-| `input` beyond 32,767 bytes rejected | all | Truncate before sending and record the truncation — never imply the unchecked tail passed |
+| `input` beyond 32,767 bytes rejected | all | Route oversized input to `:parse` (no cap) or reject it — never highlight a truncated copy and present it as validating the whole script |
 | Highlight latency cliff near 28 KB | observed 7.23.x | Prefer a `:parse` pre-check for big scripts (no such cliff, no 32 KB cap) |
 
 - **Distinguish `[]`, timeout, and transport failure.** An empty array is a

--- a/routeros-syntax-inspection/SKILL.md
+++ b/routeros-syntax-inspection/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: routeros-syntax-inspection
+description: "Inspecting and validating RouterOS command/script syntax against a live device via /console/inspect (highlight, completion, syntax, child) and :parse IL. Use when: validating RouterOS commands before execution, explaining or linting RouterOS scripts, building syntax-aware tooling (LSP servers, validators, agent explain/check commands), interpreting highlight token streams or :parse intermediate language, discovering enum values or argument schemas, or when the user mentions console/inspect, highlight tokens, parseIL, or RouterOS script validation."
+---
+
+# RouterOS Syntax Inspection
+
+## Overview
+
+RouterOS exposes its **own parser** over the REST API: `/console/inspect`
+classifies every byte of console input (`highlight`), proposes continuations
+(`completion`), returns structured help (`syntax`), and enumerates the command
+tree (`child`); the `:parse` scripting command returns the intermediate
+language (IL) the engine actually executes. Together these are the ground
+truth for "is this valid RouterOS?" — version-exact, package-exact, and even
+runtime-state-exact, which no static grammar can be.
+
+This skill is a **probe-selection and wire-format guide**: which surface
+answers which question, how to read each response, and which claims the
+responses do and do not support. It is grounded in full-corpus captures
+(913 scripts × multiple RouterOS versions) published in
+[tikoci/lsp-routeros-ts](https://github.com/tikoci/lsp-routeros-ts) — the
+`docs/` references there carry the full evidence [^1].
+
+**"Parse RouterOS" is not one operation.** Pick the probe for the question:
+
+| Question | Probe | What it cannot establish |
+|---|---|---|
+| Which span is a command, argument, variable, comment, live-state marker? | `request=highlight` | Nested structure; value validity; anything after the first hard error |
+| Is the script structurally valid; what blocks/expressions result? | `:parse` | Source ranges; partial IL on error; path/argument split without schema data |
+| What is valid at this cursor position? Enum values? | `request=completion` | Requiredness; exhaustiveness of candidate lists; runtime acceptance |
+| What paths, commands, arguments exist on this device? | `request=child` + `request=syntax` | Enum values (those come from `completion`); required arguments |
+| Which arguments are required? | Execute-error probe (`add` with no args) | Conditional requirements past the first discriminator |
+
+Details per surface: [references/highlight.md](references/highlight.md),
+[references/parseil.md](references/parseil.md),
+[references/command-schema.md](references/command-schema.md),
+[references/validation.md](references/validation.md).
+
+For crawling the full command hierarchy (`child` traversal, schema/RAML/OpenAPI
+generation), see the **`routeros-command-tree`** skill — this skill covers the
+*syntax/validity* surfaces of the same `/console/inspect` endpoint.
+
+## Request shape
+
+All four inspect surfaces share one endpoint (basic auth, any RouterOS 7.x):
+
+```text
+POST /rest/console/inspect
+{"request": "highlight" | "completion" | "syntax" | "child",
+ "input": "<console input>",     // optional
+ "path":  "ip,address,add"}      // optional comma-separated menu context
+```
+
+Every successful response is a JSON array of flat all-string objects with a
+`type` field naming the request type. Beyond that, the four response shapes
+share nothing — treat them as four APIs behind one endpoint.
+
+## Version baseline and safety
+
+- **Baseline: RouterOS 7.20.8** (the first v7 long-term release). REST itself
+  exists since 7.1beta4 (HTTPS-only at first [^2]); behavior below 7.20.8 is
+  best-effort, and RouterOS v6 has no REST API at all.
+- **Always set a per-request timeout** (a few seconds). Old versions can hang
+  the whole REST server on specific inspect calls; a hung server also makes
+  *subsequent* unrelated probes appear broken.
+- **Known hazards** (all measured, see [^1] and [^3]):
+
+| Hazard | Versions | Rule |
+|---|---|---|
+| `request=syntax`/`completion` at bare path `do` deadlocks the REST server | ≤ 7.20.8 (fixed by 7.21.4) [^3] | Skip scripting-keyword paths (`where`, `do`, `else`, `rule`, `command`, `on-error`) on old/unknown versions; it is a conservative skip policy, not a timeless six-path crash rule |
+| `request=syntax` with `input`, or command-level `syntax`, stalls ~60 s | observed on 7.9.2 | Query `syntax` by `path` only; feature-detect command-level lookups with a short timeout |
+| `input` beyond 32,767 bytes rejected | all | Truncate before sending and record the truncation — never imply the unchecked tail passed |
+| Highlight latency cliff near 28 KB | observed 7.23.x | Prefer a `:parse` pre-check for big scripts (no such cliff, no 32 KB cap) |
+
+- **Distinguish `[]`, timeout, and transport failure.** An empty array is a
+  real answer (nonexistent path); a timeout is not. Conflating them corrupts
+  any cached conclusion.
+
+## Reading results — rules that prevent wrong claims
+
+These are the measured behaviors that most often get summarized wrongly:
+
+1. **Offsets and tokens are byte-based.** RouterOS strings are single-byte
+   data — the console has no Unicode awareness. Highlight emits exactly one
+   token per input **byte**, and completion `offset` counts bytes as received
+   on the wire (UTF-8 over REST, so non-ASCII characters occupy 2+ bytes and
+   desynchronize byte offsets from UTF-16/JS string indexes). ASCII-normalize
+   input first — replacing each char > 127 with one ASCII byte (`?`) keeps
+   editor character positions aligned to RouterOS byte positions.
+2. **One hard error, then silence.** Both highlight and `:parse` stop at the
+   first hard error. Highlight marks exactly one `error` byte and leaves the
+   rest unclassified (`none`); `:parse` returns a message with line/column
+   and **no partial IL**. Neither gives multi-error diagnostics in one call.
+   Soft markers (`obj-*`, `variable-undefined`, `syntax-obsolete`) do *not*
+   stop classification.
+3. **`none` means unclassified, not "valid literal."** Highlight accepts an
+   obviously bad IP as `none`. Value validation is a different layer.
+4. **`obj-inactive` / `obj-disabled` / `obj-dynamic` are live-state
+   classifications, not grammar errors.** A disabled service or dynamic route
+   table is a perfectly valid reference. Diagnostic severity is the
+   consumer's policy decision — do not hard-code these as "invalid syntax."
+5. **An undeclared `$name` is usually not an error.** It classifies as
+   `variable-parameter` (it may be supplied at call time). The "probably a
+   typo" signal is `variable-undefined` — a bare unresolvable identifier in
+   expression position.
+6. **Completion candidates are observed suggestions, not proven-closed
+   enums.** Preserve "observed candidates" provenance unless independent
+   evidence proves closure.
+7. **Results are stateful.** Token classes and candidates depend on the
+   RouterOS version, installed packages, and current object flags. Record
+   version + package manifest with any captured result; a snapshot from one
+   router is only approximately valid for another.
+
+## Validating a command via completion
+
+The grounded mechanics of "check before you run" (full detail:
+[references/command-schema.md](references/command-schema.md)):
+
+- Probe with the cursor **immediately after the word under test** — before
+  `=`, whitespace, or the next token. Completion verdicts are cursor-local:
+  advancing past an invalid word can hide its sentinel.
+- Sentinel rows (`preference:"-20"`, empty `completion`,
+  `text:"unknown command"`/`"unknown parameter"`) classify **the word at
+  their `offset`** — and also appear *prospectively* at the end of valid
+  input, so presence alone is not a verdict. Decision rule (7.21+):
+  sentinel with no completing candidate → unknown name; sentinel plus
+  candidates at the same offset → ambiguous prefix; candidates only → valid
+  partial; a nonexistent *path* returns `[]` outright.
+- Feature-detect on old versions: 7.9.2 emits the unknown-*command* sentinel
+  but returns bare `[]` for an unknown typed *argument*.
+- **Passing inspect validation is necessary, not sufficient.** There is a
+  measured inspect-vs-runtime gap: `/console/inspect` accepts forms the
+  device rejects at execution (e.g. `blackhole=yes` on a route, where the
+  runtime wants the bare `blackhole` flag) [^4]. Only execution on an
+  appropriate target proves runtime acceptance.
+
+## Minimum pipeline for a syntax "explain"
+
+1. **Segment** input statically (find command boundaries; preserve offsets).
+2. **highlight** the ASCII-normalized input → lexical spans + first error.
+3. **`:parse`** only when structure or an error message is needed → nested IL
+   or line/column message. Align its error with highlight's error byte.
+4. **`child`/`syntax`/`completion`** (or a same-version schema snapshot) →
+   split IL's fused path/argument forms, enumerate arguments, fetch enums.
+5. **Enrich** with docs/changelog prose — but the live device wins for what
+   its inspect surface exposes; only execution proves runtime acceptance.
+
+Steps 1–2 suffice for a lightweight explain; block/scope analysis needs 3;
+rich command help needs 4–5. Execution probes (required-args discovery,
+`/rest/execute`) mutate state — run them only on explicit request against an
+appropriate target.
+
+Whatever the depth, keep provenance with every derived fact: source probe,
+RouterOS version + packages, path context, whether the claim is a direct
+response or derived, normalization applied, truncation, and outcome
+(`ok` / `empty` / `timeout` / `transport-error`).
+
+## References
+
+- [references/highlight.md](references/highlight.md) — per-byte token stream:
+  vocabulary, error model, statefulness, drift.
+- [references/parseil.md](references/parseil.md) — `:parse` IL: readout
+  recipe, grammar, canonicalizations, error behavior.
+- [references/command-schema.md](references/command-schema.md) —
+  `child`/`syntax`/`completion` response shapes, enum discovery, sentinels.
+- [references/validation.md](references/validation.md) — required-argument
+  probing and layering live vs static evidence.
+
+[^1]: Full format references with capture artifacts:
+    [`highlight-format.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/highlight-format.md),
+    [`parseil-format.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/parseil-format.md),
+    [`inspect-shapes.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/inspect-shapes.md)
+    in tikoci/lsp-routeros-ts — 913-script corpus swept on 7.9.2/7.23.2/7.24rc2
+    (highlight, inspect shapes) and 7.20.8/7.22.1/7.23rc1 (parseIL).
+[^2]: MikroTik REST API introduction in 7.1beta4:
+    <https://help.mikrotik.com/docs/spaces/ROS/pages/47579162/REST+API>.
+[^3]: MikroTik support case SUP-127641; per-version probe data in
+    [tikoci/restraml](https://github.com/tikoci/restraml) (`deep-inspect.ts`
+    `CRASH_PATHS` notes and `docs/<version>/deep-inspect.json`
+    `crashPathsCrashed`): bare `do` hangs `syntax`/`completion` on 7.20.8 at
+    both 128 MB and 512 MB RAM; all six paths return instantly on 7.21.4+.
+[^4]: [tikoci/bench-routeros-tools](https://github.com/tikoci/bench-routeros-tools)
+    `REPORT.md` — the `blackhole=yes` inspect-vs-runtime case.

--- a/routeros-syntax-inspection/references/command-schema.md
+++ b/routeros-syntax-inspection/references/command-schema.md
@@ -1,0 +1,106 @@
+# `child`, `syntax`, `completion` — schema and candidates
+
+The three non-highlight request types of `/console/inspect`. Grounded on a
+37-context probe catalog captured verbatim on RouterOS 7.9.2, 7.23.2, and
+7.24rc2:
+[`inspect-shapes.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/inspect-shapes.md)
+(artifacts in that repo's `test-data/inspect-shapes.v<version>.json`).
+
+Observed field sets are identical across all three versions; item counts and
+candidate contents track the live device's schema and state.
+
+## `request=child` — node enumeration
+
+Items: `{name, node-type: "dir"|"path"|"cmd"|"arg", type: "self"|"child"}`.
+
+- `type:"self"` describes the addressed node itself; `"child"` rows are its
+  children. A name that is both a command and an argument returns both rows.
+- Root (`path:""`) lists every top-level menu and scripting command.
+- **A nonexistent path returns `[]`, not an error** — absence is the only
+  "not found" signal.
+- `input` is **ignored**; filtering is the caller's job.
+
+This is the surface schema crawlers (e.g.
+[tikoci/restraml](https://github.com/tikoci/restraml)) walk; see the
+`routeros-command-tree` skill for traversal recipes.
+
+## `request=syntax` — structured help
+
+Not just a description string. Full item:
+
+```json
+{"symbol": "Address", "symbol-type": "definition",
+ "text": "A.B.C.D    (IP address)",
+ "nested": "0", "nonorm": "false", "type": "syntax"}
+```
+
+- `symbol-type` discriminates: `definition` (the addressed node's own entry —
+  for a value-typed arg, `text` is the **value-type notation**, the closest
+  thing this API has to a type grammar), `explanation` (one row per member
+  of a container: querying a command returns every argument's description),
+  `collection` (the container row). `nested` behaves like row depth.
+- **Enum-valued args return an empty definition** — enum values live in
+  `completion`, not `syntax`.
+- On 7.21.4+, one `syntax` call on a *command* returns all of its arguments'
+  descriptions at once — much cheaper than per-arg lookups. **Feature-detect
+  with a short timeout**: on 7.9.2 the same command-level lookup stalled
+  ~60 s; combining `input` with `syntax` also hangs there (on 7.23.x it just
+  degrades to a lone empty row). Query `syntax` by `path` only.
+- Scripting-keyword paths (`where`, `do`, `else`, `rule`, `command`,
+  `on-error`): bare `do` with `syntax`/`completion` deadlocks the REST server
+  on ≤ 7.20.8, fixed by 7.21.4 (restraml's live matrix, MikroTik case
+  SUP-127641). Keep the six-path skip as conservative policy on old/unknown
+  versions.
+
+## `request=completion` — candidates, enums, validity signal
+
+Each item proposes text that could continue or repair the input:
+
+| Field | Meaning (observed) |
+|---|---|
+| `completion` | Candidate text; empty string on sentinel rows |
+| `offset` | **Byte offset into `input`** where replacement begins (RouterOS counts raw bytes as received; the REST wire is UTF-8, so non-ASCII shifts offsets off JS/UTF-16 indexes — ASCII-normalize first). End-of-input = append; smaller = replaces the partial word |
+| `preference` | Observed ranking weight, not a documented enum. Typical: `96` names, `95` separators, `75` expression openers, `40` statement glue, `-1` hidden placeholders, `-10` obsolete-syntax, `-20` unknown-name sentinels |
+| `show` | `"true"` = display as candidate; `"false"` = machine-facing row (connectives, placeholders, sentinels). Not a validity flag |
+| `style` | Highlight-vocabulary class the candidate is associated with (`dir`, `cmd`, `arg`, `variable-local`, `obj-inactive`, …) |
+| `text` | Human description (menu blurb, arg description, sentinel reason) |
+
+Grounded uses:
+
+- **Enum-candidate discovery**: `input:"/ip/firewall/filter/add action="`
+  returns the enum-looking value set as `show:"true"` rows — the only inspect
+  source for enum values. Treat the list as *observed candidates*, not a
+  proven-closed set.
+- **Live-object values**: `interface=` completes with the device's actual
+  interfaces — stateful by design.
+- **`where`-clause fields** complete as `style:"variable-local"` — consistent
+  with highlight's classing and parseIL's `findwhere=` dump.
+- **Value-position grammar**: after `word=` a `completion:"<value>"`,
+  `preference:"-1"` placeholder row describes the generic literal grammar —
+  a hint, not proof the preceding argument or value is valid.
+
+### Validity checking (the sentinel decision rule)
+
+Sentinel rows — empty `completion`, `preference:"-20"`,
+`style:"obj-inactive"`, `text:"unknown command"`/`"unknown parameter"` —
+classify **the word starting at their `offset`**, and also appear
+*prospectively* at the empty end-of-input position of valid commands.
+Probe with the cursor immediately after the word under test (before `=` or
+whitespace — verdicts are cursor-local and advancing can hide an earlier
+word's sentinel). Then, per word (measured on 7.23.2/7.24rc2):
+
+- sentinel at the word's offset and **no** `show:"true"` candidate completing
+  it → unknown name;
+- sentinel **plus** candidates at the same offset → ambiguous prefix;
+- candidates only → valid partial;
+- sentinel at end-of-input → prospective; ignore.
+- a nonexistent *path* returns `[]` outright (same absence signal as
+  `child`).
+
+Version caveat: 7.9.2 still emits the unknown-*command* sentinel but returns
+bare `[]` for an unknown typed *argument* — feature-detect the argument rule.
+
+**Necessary, not sufficient**: inspect accepts some forms the runtime
+rejects (the `blackhole=yes` case in
+[tikoci/bench-routeros-tools](https://github.com/tikoci/bench-routeros-tools)).
+Only execution on an appropriate target proves acceptance.

--- a/routeros-syntax-inspection/references/highlight.md
+++ b/routeros-syntax-inspection/references/highlight.md
@@ -1,0 +1,109 @@
+# `request=highlight` — the per-byte token stream
+
+The console's own tokenizer, exposed verbatim. This is the lexical view of a
+script: which class every byte belongs to. Full evidence (corpus counts,
+timing, drift tables):
+[`highlight-format.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/highlight-format.md).
+
+## Wire format
+
+```text
+POST /rest/console/inspect
+{"request": "highlight", "input": ":put 1"}
+
+→ [{"highlight": "dir,cmd,cmd,cmd,none,none", "type": "highlight"}]
+```
+
+- `highlight` is a comma-joined list of class names, **exactly one per input
+  byte** (verified across 913 corpus files on 7.9.2, 7.23.2, 7.24rc2).
+- Empty input returns `"highlight": ""` — zero tokens. Guard before
+  splitting: naïve `"".split(',')` fabricates one empty-named token.
+- The response array always contains exactly one item.
+- Optional `path` (comma-separated, e.g. `"ip,address"`) classifies the input
+  as if typed at that menu prompt.
+
+**Send ASCII.** Non-ASCII is accepted but each byte gets a token, so token
+indexes desynchronize from editor character offsets. Replace each char > 127
+with one ASCII byte (`?`) before sending; non-ASCII in identifier position is
+rejected by RouterOS itself anyway, and inside strings/comments the
+substitution is harmless (measured: only 4 of 333 corpus error files trace to
+substitution).
+
+**Limits:** input over 32,767 bytes is rejected; latency grows with size and
+complexity (corpus mean ~79 ms, p95 ~277 ms, with a cliff near 28 KB —
+`:parse` has neither the cap nor the cliff).
+
+## Token vocabulary (19 classes observed)
+
+Identical on 7.23.2 and 7.24rc2; 7.9.2 lacks only `arg-scope`/`arg-dot`
+(dotted argument names postdate it).
+
+### Structure
+
+| Class | Meaning (observed) |
+|---|---|
+| `none` | Everything unclassified: whitespace, literal values (numbers, string contents, IPs, times), and **all text after a hard error** |
+| `dir` | Menu-path segments *including their slashes* (`/ip/address/` is one run); also the `:` sigil of scripting commands |
+| `cmd` | Command name (`print`, `add`, `local`, `if` …) |
+| `arg` | Argument name before `=` |
+| `arg-scope` / `arg-dot` | Prefix / dot of a dotted argument (`export.route-targets=`); suffix is plain `arg` |
+| `syntax-meta` | Syntactic punctuation: quotes, `$`, `=`, `{`, `}`, `(`, `)`, `;`, `[`, `]`, `,` |
+| `escaped` | Escape sequences in strings (`\"`, `\n`, hex escapes, line-continuation backslash) |
+| `comment` | Whole comment including `#` |
+
+### Variables
+
+| Class | Meaning (observed) |
+|---|---|
+| `variable-local` | `:local`-declared name, at declaration and use. **Also menu-property names in `where`/filter expressions** — the console binds the menu's fields as locals |
+| `variable-global` | `:global`-declared name |
+| `variable-auto` | Loop-bound names (`:foreach k,v`, `:for i`) |
+| `variable-parameter` | Function parameters (`$1`, named params in `do={}`) — **and any `$name` with no visible declaration**; undeclared is indistinguishable from supplied-at-call-time |
+| `variable-undefined` | Bare unresolvable identifier in expression position — the actual "probably a typo" signal |
+
+### State and error
+
+| Class | Meaning (observed) |
+|---|---|
+| `obj-inactive` | Name that doesn't resolve *on this device*: unknown command/argument/menu, or an ambiguous prefix. Soft — classification continues |
+| `obj-disabled` | Reference to an object whose disabled flag is currently set on the live device |
+| `obj-dynamic` | Reference to an object that is currently dynamic on the live device |
+| `syntax-obsolete` | Accepted-but-deprecated syntax, marked on the divergence character (e.g. the space in old-style `} else {`) |
+| `error` | Hard parse error — always exactly **one byte**; see below |
+
+## The error model — one byte, then silence
+
+`error` marks the first byte the parser cannot proceed past, and only that
+byte; everything after it in the whole input is `none`. Measured: never two
+`error` bytes in one response across 913 files × 3 versions. Consequences:
+
+- One request yields at most one hard-error position — highlight does **not**
+  mark every error. Everything *before* the error stays fully classified
+  (including soft markers), and the error position is byte-exact.
+- Multi-error diagnostics require iterative re-requests past each error.
+- Pair with `:parse` for message + range: highlight gives the exact byte
+  without a message; `:parse` gives a message with line/column.
+
+Common triggers: descending into an unresolvable path (the unknown name is
+soft `obj-inactive`; the `/` that tries to *enter* it is the `error`),
+non-script content (pasted transcripts), a byte that can't start a token in
+code position, `:set` on an undeclared name.
+
+**Severity is consumer policy.** Only `error` is the measured hard stop.
+Treating `obj-disabled`, `obj-dynamic`, or `syntax-obsolete` as errors is a
+product decision (an LSP may want it; a validator probably does not).
+
+## Statefulness and drift
+
+The same input tokenizes differently across devices or device states:
+version/command-tree churn, installed packages, runtime object flags
+(`obj-disabled`/`obj-dynamic`), and declared globals all shift classes.
+Measured drift 7.23.2 → 7.24rc2: vocabulary identical, 97.6% of files
+byte-identical, all differences schema churn. 7.9.2 was *harsher* (unknown
+argument = hard `error` rather than soft `obj-inactive`) but same wire
+format.
+
+Do not confuse the highlight vocabulary with `/terminal/style`'s 12
+display-style names (`varname`, `syntax-val`, `ambiguous`, …) — that is the
+console's *rendering palette*, overlapping on only five names, and those
+style names never appear on the highlight wire.

--- a/routeros-syntax-inspection/references/parseil.md
+++ b/routeros-syntax-inspection/references/parseil.md
@@ -20,13 +20,17 @@ collapse to the placeholder `(code)`):
 Over REST, avoid string-escape collisions by uploading first:
 
 ```text
-POST /rest/file/add     {"name":"probe.rsc","contents":"...script..."}
-POST /rest/execute      {"script":":put [:parse [/file/get probe.rsc contents]]","as-string":"true"}
-POST /rest/file/remove  {"numbers":"probe.rsc"}
+# use a per-run unique NAME (e.g. parse-<nonce>.rsc) so concurrent probes and
+# any pre-existing file can't collide; /file/add fails on a name that exists
+POST /rest/file/add     {"name":"parse-<nonce>.rsc","contents":"...script..."}
+POST /rest/execute      {"script":":put [:parse [/file/get parse-<nonce>.rsc contents]]","as-string":"true"}
+POST /rest/file/remove  {"numbers":"parse-<nonce>.rsc"}
 ```
 
 Note this recipe touches `/file` and `/rest/execute` — inspection-flavored
-but not purely read-only. Limits: `/rest/file/add` returns 413 above the
+but not purely read-only. Remove the temp file on **both** the success and
+error paths (an interrupted probe otherwise leaves it behind and the next
+`add` of the same name fails). Limits: `/rest/file/add` returns 413 above the
 upload cap (~126 KiB observed); `:parse` itself has **no 32 KB cap** and no
 latency cliff (56 KB parsed cleanly; ≤10 ms typical for small scripts).
 
@@ -91,4 +95,4 @@ Version-tag any stored IL.
 | Blocks, scopes, functions | `:parse` |
 | Canonical value forms | `:parse` |
 | Scripts > 32 KB | `:parse` (no cap) |
-| Cheap validity pre-check | `:parse` (~10 ms, no 28 KB cliff) |
+| Cheap structural pre-check (unknown commands late-bind, so not a full validity check) | `:parse` (~10 ms, no 28 KB cliff) |

--- a/routeros-syntax-inspection/references/parseil.md
+++ b/routeros-syntax-inspection/references/parseil.md
@@ -1,0 +1,94 @@
+# `:parse` IL — the structural view
+
+`:parse` lowers a script to the textual intermediate language ("parseIL") the
+RouterOS engine executes. It is the structural complement to highlight's flat
+token stream: blocks, expressions, scopes, evaluation order. Full grammar and
+corpus evidence:
+[`parseil-format.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/parseil-format.md)
+(913-script corpus on 7.20.8 / 7.22.1 / 7.23rc1).
+
+## Readout recipe
+
+Only `:put` reveals the IL (`:tostr`, `:serialize`, environment printing all
+collapse to the placeholder `(code)`):
+
+```routeros
+:put [:parse ":put hello"]
+# (evl /putmessage=hello)
+```
+
+Over REST, avoid string-escape collisions by uploading first:
+
+```text
+POST /rest/file/add     {"name":"probe.rsc","contents":"...script..."}
+POST /rest/execute      {"script":":put [:parse [/file/get probe.rsc contents]]","as-string":"true"}
+POST /rest/file/remove  {"numbers":"probe.rsc"}
+```
+
+Note this recipe touches `/file` and `/rest/execute` — inspection-flavored
+but not purely read-only. Limits: `/rest/file/add` returns 413 above the
+upload cap (~126 KiB observed); `:parse` itself has **no 32 KB cap** and no
+latency cliff (56 KB parsed cleanly; ≤10 ms typical for small scripts).
+
+## Grammar essentials
+
+- A script is a `;`-separated sequence of `(evl …)` forms. Empty source →
+  empty IL; comment-only source → the single character `/`.
+- `(evl <PATH><ARGS>)` — path and args are fused with **no separator**
+  (`/localname=$x` = path `/local` + args `name=$x`). Splitting them
+  deterministically requires the command schema (`child`/`syntax`).
+- Block-valued args (`do={…}`, `else={…}`, `on-error={…}`) appear as the key
+  with empty value (`do=;`) followed by the block body as an adjacent
+  `(evl …)` sibling. Multi-statement blocks wrap as
+  `(evl <child> <child> …)` with space-separated children.
+- Expressions are Lisp-style prefix forms: `(= 1 1)`, `(+ 1 2)`,
+  `(. "now=" $now)`, `(and … …)`, `(~ $addr 10.0.0.0)`.
+- Two real (undocumented) operators appear: `(> …)` quotes code into an `op`
+  value; `(<%% …)` applies an op/function in an explicit environment. Both
+  labels come from `request=completion` itself (`quote`, "activate in
+  environment").
+- Variable references are textual `$name` with **no scope information** —
+  local/global/parameter resolution requires reconstructing scopes from the
+  surrounding `/local`/`/global` declarations and `do=` boundaries.
+
+## Canonicalizations (useful for "RouterOS will see this as…")
+
+- Paths fully qualify: `:put` → `/put`; `/ip address print` →
+  `/ip/address/print`. No implicit current menu in the IL.
+- `yes`/`no` → `true`/`false`; time literals expand (`200ms` →
+  `00:00:00.200`).
+- `find`/`where` forms dump **every property of the target menu** as
+  `findwhere=$field;…` — the whole field set, not just referenced fields.
+  Version-sensitive (the main source of cross-version IL drift), and useful
+  for version-aware property enumeration. It carries **no required-vs-optional
+  signal** (see [validation.md](validation.md)).
+
+## Errors
+
+At the first error `:parse` stops: an error string with `(line N column M)`
+and **no partial IL**. Observed stems: `syntax error`,
+`expected end of command`, `missing closing brace`, `missing value for
+where`. One special case embeds the error *inside* IL: an unknown command
+name lowers to a `(<%% bad command name … )` form — late-binding rather than
+parse-fatal. Error wording and coordinates are **not stable across
+versions**; match stems loosely.
+
+## Drift
+
+91.9% of the corpus is byte-identical across 7.20.8/7.22.1/7.23rc1. All
+drift is schema leakage (the `findwhere=` dumps, path re-canonicalization
+like `/ping` → `/tool/ping`, parameter validation churn) — the core IL
+surface (`(evl …)`, `;`, prefix ops, `(> …)`, `(<%% …)`) did not change.
+Version-tag any stored IL.
+
+## Choosing highlight vs `:parse`
+
+| Question | Use |
+|---|---|
+| Token class at each byte / editor coloring | highlight |
+| First-error position | either — highlight: exact byte, no message; `:parse`: line/column + message. Pair them |
+| All errors in one call | neither (both stop at the first hard error) |
+| Blocks, scopes, functions | `:parse` |
+| Canonical value forms | `:parse` |
+| Scripts > 32 KB | `:parse` (no cap) |
+| Cheap validity pre-check | `:parse` (~10 ms, no 28 KB cliff) |

--- a/routeros-syntax-inspection/references/validation.md
+++ b/routeros-syntax-inspection/references/validation.md
@@ -1,0 +1,66 @@
+# Required arguments and evidence layering
+
+## No inspect surface exposes requiredness
+
+Measured across `/console/inspect` and parseIL (evidence:
+[`parseil-format.md` §5.2](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/parseil-format.md)
+and
+[`required-args.md`](https://github.com/tikoci/lsp-routeros-ts/blob/main/docs/required-args.md)):
+
+- `completion` returns every `add` argument with identical metadata
+  (`preference:96`, `style:"arg"`) — no `required` field, no priority split.
+- `syntax` descriptions carry type hints, not requiredness.
+- parseIL's `findwhere=` dump lists **every** property of a menu (required,
+  optional, and read-only alike) — the only structural asymmetry is that
+  positional-insertion args like `place-before` never appear in it.
+
+## The execute-error probe — the one reliable signal
+
+Running `add` with no arguments produces a machine-parseable error:
+
+```text
+Script Error: missing value(s) of argument(s) <arg1> <arg2> … (<path>/add; line 1)
+```
+
+Probe shape (creates and immediately removes a row when `add` succeeds):
+
+```routeros
+:local id [/some/menu add]; :put $id; /some/menu remove $id
+```
+
+**This is an execution probe, not inspection** — it can mutate state (an
+interrupted run leaves a row behind; some menus have side effects). Run it
+only against a disposable target (e.g. a lab CHR) and never as part of a
+read-only explain path.
+
+Measured on 7.20.8 / 7.22.1 / 7.23rc1 (~230 add-capable paths each):
+~65% of paths report the exact `missing value(s)` pattern, ~22% need no
+arguments at all, ~9% use custom human text (`"address or mac-address is
+required"`, one-of rules), and a handful error out (read-only or stateful
+menus). Caveats:
+
+- Custom-text rows encode **one-of / conditional** rules — keep the raw
+  message as the source of truth, don't flatten to a set.
+- Conditional requirements need a second pass after providing the
+  discriminator (`/disk add type=iscsi` then requires `iscsi-address`).
+- The result is **version-specific**: required sets drift across releases
+  (six paths changed across the three captured versions). Key any cached map
+  by menu path + RouterOS version.
+
+## Layering live and static evidence
+
+When a live device and a static snapshot (schema dump, docs) disagree:
+
+- The **live target wins** for what its inspect surface exposes — existence,
+  token classes, candidates.
+- **Only execution proves runtime acceptance** — inspect has measured
+  false-accepts (see
+  [command-schema.md](command-schema.md)).
+- **Static sources win** only for what they uniquely provide: prose,
+  history/changelogs, cross-version comparisons.
+
+Keep every derived fact answerable to "how do we know?": record the source
+probe, whether the claim is a direct response or derived, RouterOS version +
+installed packages, path context, input normalization/truncation, and the
+outcome class (`ok` / `empty` / `timeout` / `transport-error`) — an empty
+array is an answer; a timeout is not.

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  echo "usage: $0 {link|check|unlink|targets}" >&2
+}
+
+cmd="${1:-}"
+if [ -z "$cmd" ]; then
+  usage
+  exit 2
+fi
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+
+targets="
+$HOME/.copilot/skills
+$HOME/.claude/skills
+$HOME/.agents/skills
+"
+
+same_target() {
+  actual=${1%/}
+  expected=${2%/}
+  [ "$actual" = "$expected" ]
+}
+
+skill_names() {
+  find "$repo" -mindepth 1 -maxdepth 1 -type d -name 'routeros-*' -exec basename {} \; | sort
+}
+
+link_one() {
+  src=$1
+  dst=$2
+
+  if [ -L "$dst" ]; then
+    actual=$(readlink "$dst")
+    if same_target "$actual" "$src"; then
+      return 0
+    fi
+    rm "$dst"
+  elif [ -e "$dst" ]; then
+    echo "CONFLICT: $dst exists and is not a symlink" >&2
+    return 1
+  fi
+
+  ln -s "$src" "$dst"
+  echo "linked  $dst"
+}
+
+unlink_one() {
+  src=$1
+  dst=$2
+
+  if [ -L "$dst" ]; then
+    actual=$(readlink "$dst")
+    if same_target "$actual" "$src"; then
+      rm "$dst"
+      echo "removed $dst"
+    fi
+  fi
+}
+
+check_one() {
+  src=$1
+  dst=$2
+
+  if [ ! -e "$src/SKILL.md" ]; then
+    echo "NO SKILL.md: $src" >&2
+    return 1
+  fi
+
+  if [ ! -e "$dst" ]; then
+    echo "MISSING:  $dst" >&2
+    return 1
+  fi
+
+  if [ ! -L "$dst" ]; then
+    echo "NOT LINK: $dst" >&2
+    return 1
+  fi
+
+  actual=$(readlink "$dst")
+  if ! same_target "$actual" "$src"; then
+    echo "WRONG:    $dst -> $actual (expected $src)" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+case "$cmd" in
+  targets)
+    for target in $targets; do
+      echo "$target"
+    done
+    ;;
+  link)
+    rc=0
+    for target in $targets; do
+      mkdir -p "$target"
+      for skill in $(skill_names); do
+        link_one "$repo/$skill" "$target/$skill" || rc=1
+      done
+    done
+    echo "link: done"
+    exit "$rc"
+    ;;
+  unlink)
+    for target in $targets; do
+      for skill in $(skill_names); do
+        unlink_one "$repo/$skill" "$target/$skill"
+      done
+    done
+    echo "unlink: done"
+    ;;
+  check)
+    rc=0
+    count=0
+    for skill in $(skill_names); do
+      count=$((count + 1))
+      for target in $targets; do
+        check_one "$repo/$skill" "$target/$skill" || rc=1
+      done
+    done
+    if [ "$rc" -eq 0 ]; then
+      echo "check: all $count skills linked into all target dirs"
+    fi
+    exit "$rc"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -27,7 +27,12 @@ same_target() {
 }
 
 skill_names() {
-  find "$repo" -mindepth 1 -maxdepth 1 -type d -name 'routeros-*' -exec basename {} \; | sort
+  # POSIX glob (portable across BSD/macOS + GNU); trailing slash matches dirs only.
+  for dir in "$repo"/routeros-*/; do
+    [ -d "$dir" ] || continue   # no-match: the literal glob survives, -d skips it
+    name=${dir%/}
+    echo "${name##*/}"
+  done | sort
 }
 
 link_one() {
@@ -71,23 +76,24 @@ check_one() {
     return 1
   fi
 
+  # Check -L before -e: a broken symlink (target missing) is a WRONG link, not
+  # MISSING — -e follows the link and would hide it, losing the readlink target.
+  if [ -L "$dst" ]; then
+    actual=$(readlink "$dst")
+    if ! same_target "$actual" "$src"; then
+      echo "WRONG:    $dst -> $actual (expected $src)" >&2
+      return 1
+    fi
+    return 0
+  fi
+
   if [ ! -e "$dst" ]; then
     echo "MISSING:  $dst" >&2
     return 1
   fi
 
-  if [ ! -L "$dst" ]; then
-    echo "NOT LINK: $dst" >&2
-    return 1
-  fi
-
-  actual=$(readlink "$dst")
-  if ! same_target "$actual" "$src"; then
-    echo "WRONG:    $dst -> $actual (expected $src)" >&2
-    return 1
-  fi
-
-  return 0
+  echo "NOT LINK: $dst" >&2
+  return 1
 }
 
 case "$cmd" in


### PR DESCRIPTION
Two independent changes, one per commit.

## `chore(tooling)` — Codex skill dir + `link-skills.sh`
Add `~/.agents/skills` (Codex user-authored skills) as a third symlink target alongside Copilot and Claude. Extract the link/unlink/check logic out of the `Makefile` into `scripts/link-skills.sh` so all three assistants share one implementation. The script verifies each target is a symlink pointing at this repo (`CONFLICT`/`NOT LINK`/`WRONG`), normalizes trailing slashes for idempotent re-linking, and adds a `targets` subcommand. README/SETUP/hooks updated for all three dirs.

> Note: `~/.agents/skills` is the Codex *user*-skills dir; `~/.codex/skills` holds Codex-managed/system skills and is intentionally not a target.

## `feat(routeros-syntax-inspection)` — new skill
A probe-selection and wire-format guide for the syntax/validity surfaces of `/console/inspect` (`highlight`, `completion`, `syntax`, `child`) and the `:parse` intermediate language — which probe answers which question, per-byte highlight token vocabulary + error model, parseIL grammar/canonicalizations, enum discovery, the completion sentinel decision rule, and required-argument probing.

Grounded in:
- the 913-script corpus + format docs in `tikoci/lsp-routeros-ts`
- `tikoci/restraml` per-version crash-path data (`crashPathsCrashed`, MikroTik case SUP-127641)
- the `tikoci/bench-routeros-tools` inspect-vs-runtime gap (`blackhole=yes`)

Also in this commit:
- **routeros-command-tree**: downgrade the "dangerous paths crash the server" folklore to the measured facts — bare `do` with `syntax`/`completion` deadlocks ≤7.20.8 (fixed 7.21.4); the other five return instantly. Keep the six-path list as a conservative crawler skip policy. Cross-links the new skill.
- **routeros-quickchr**: point at `examples/quickstart` + `COVERAGE.md` (`vienk` renamed).
- **README** / **project-words.txt**: register the new skill; add its dictionary terms.

## Verification
`make lint` green locally: markdownlint 0, cspell 0, validator 14 skills valid, lychee 0 broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RouterOS Syntax Inspection guidance covering highlighting, completion, parsing, validation, and safety considerations.
  * Added automated skill linking and verification across supported assistant skill directories.
  * Added setup targets for hooks, code linting, and offline documentation link checks.
* **Documentation**
  * Updated setup instructions and repository guidance for broader assistant support, including Codex.
  * Expanded RouterOS command-tree and quickstart documentation with clearer behavior and safety details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->