### PR TITLE
docs(routeros-fundamentals): note /rest/execute HTTP 200 rejection case

### DIFF
--- a/routeros-fundamentals/references/rest-api-patterns.md
+++ b/routeros-fundamentals/references/rest-api-patterns.md
@@ -92,6 +92,39 @@ if (!response.ok) {
 }
 ```
 
+**Scope:** this is the resource-endpoint contract. `/rest/execute` reports command
+failures differently — see below.
+
+### `/rest/execute` can return HTTP 200 for a rejected command
+
+A command RouterOS rejects can still come back **HTTP 200**, with the error text
+as the `ret` string — the same envelope a successful call returns:
+
+| Request body (`POST /rest/execute`) | Response | Status |
+|---|---|---|
+| `{"script":":put 1","as-string":""}` | `{"ret":"1"}` | `200` |
+| `{"script":"/ip/service/set www-ssl certificate=nope","as-string":""}` | `{"ret":"input does not match any value of certificate (/ip/service/set (certificate); line 1)"}` | `200` |
+
+The same operation via the resource endpoint reports it as an error:
+
+```http
+PATCH /rest/ip/service/*6
+{"certificate":"nope"}
+
+400 {"detail":"input does not match any value of certificate","error":400,"message":"Bad Request"}
+```
+
+So an `!response.ok` check does not catch this class of failure on the execute
+path. Where an equivalent resource operation exists it may give a clearer error
+contract, but confirm it for the operation at hand rather than trusting the
+status alone — a 200 from a resource endpoint is not proof of effect either (see
+the self-disable no-op in [Users REST reference](./routeros-users-rest.md)). On
+the execute path the `ret` text is the only failure signal available, and there
+is no documented general rule for telling a rejection from legitimate output.
+
+Verified on RouterOS 7.23.3 (x86 CHR), synchronous `as-string` form. The async
+job-ID form of `/rest/execute` was not tested.
+
 ## Authentication Patterns
 
 ```typescript

--- a/routeros-fundamentals/references/rest-api-patterns.md
+++ b/routeros-fundamentals/references/rest-api-patterns.md
@@ -105,7 +105,15 @@ as the `ret` string — the same envelope a successful call returns:
 | `{"script":":put 1","as-string":""}` | `{"ret":"1"}` | `200` |
 | `{"script":"/ip/service/set www-ssl certificate=nope","as-string":""}` | `{"ret":"input does not match any value of certificate (/ip/service/set (certificate); line 1)"}` | `200` |
 
-The same operation via the resource endpoint reports it as an error:
+The same operation via the resource endpoint reports it as an error. Look the
+`.id` up rather than hardcoding it — internal IDs are per-router and change when
+a record is removed and re-added:
+
+```http
+GET /rest/ip/service?name=www-ssl&.proplist=.id,name
+
+200 [{".id":"*6","name":"www-ssl"}]
+```
 
 ```http
 PATCH /rest/ip/service/*6
@@ -118,12 +126,16 @@ So an `!response.ok` check does not catch this class of failure on the execute
 path. Where an equivalent resource operation exists it may give a clearer error
 contract, but confirm it for the operation at hand rather than trusting the
 status alone — a 200 from a resource endpoint is not proof of effect either (see
-the self-disable no-op in [Users REST reference](./routeros-users-rest.md)). On
-the execute path the `ret` text is the only failure signal available, and there
-is no documented general rule for telling a rejection from legitimate output.
+the self-disable no-op in [Users REST reference](./routeros-users-rest.md)).
 
-Verified on RouterOS 7.23.3 (x86 CHR), synchronous `as-string` form. The async
-job-ID form of `/rest/execute` was not tested.
+In the case tested here the `ret` text was the only thing separating rejection
+from success, since the status and envelope were identical. Treat that as one
+grounded case rather than a contract for the whole execute path: transport
+failures, timeouts, empty results, and the asynchronous job-ID form were not
+exercised, and there is no documented general rule for telling a rejection from
+legitimate output.
+
+Verified on RouterOS 7.23.3 (x86 CHR), synchronous `as-string` form only.
 
 ## Authentication Patterns
 


### PR DESCRIPTION
While scripting certificate setup against a CHR lab instance, a rejected `/ip/service/set` sent through `/rest/execute` was indistinguishable from success at the HTTP layer, and the calling code carried on as if it had worked. The same operation against the resource endpoint returned a structured 400.

`rest-api-patterns.md`'s "Error Handling" section shows the `!response.ok` check without noting that it doesn't apply to `/rest/execute`, so this adds a scoped note there.

## Reproduction

RouterOS 7.23.3 (x86 CHR), via a plain `curl` against `/rest`:

```http
POST /rest/execute
{"script":"/ip/service/set www-ssl certificate=nope","as-string":""}

200 {"ret":"input does not match any value of certificate (/ip/service/set (certificate); line 1)"}
```

```http
POST /rest/execute
{"script":":put 1","as-string":""}

200 {"ret":"1"}
```

```http
PATCH /rest/ip/service/*6
{"certificate":"nope"}

400 {"detail":"input does not match any value of certificate","error":400,"message":"Bad Request"}
```

Success and rejection come back with the same status and the same envelope shape on the execute path, so neither distinguishes them.

## Scope

Stating what was actually tested, so the note doesn't overclaim:

- One rejected command, on 7.23.3 x86 CHR, through the **synchronous `as-string`** form only.
- The **async job-ID** form of `/rest/execute` was not tested, so the note says nothing about it.
- I haven't established whether every rejection on that path is shaped this way, so the note stops short of a general rule and points at verifying per operation instead.

The note also cross-references the existing self-disable gotcha in `routeros-users-rest.md` — that's the same lesson from the other direction: a 200 from a resource endpoint isn't proof of effect either. I wanted the addition to be consistent with what's already documented rather than implying resource endpoints are categorically reliable.

## Checks

`make lint` (markdownlint + cspell + skill validator) passes. The new relative link resolves within `routeros-fundamentals/references/`.

Happy to reword, trim, or move this to `async-commands-rest.md` alongside the `as-string` description if that's a better home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for interpreting REST API errors from command execution and resource endpoints.
  * Clarified that successful HTTP responses may still contain command failures in the response body.
  * Documented structured errors from resource endpoints and explained why a successful response does not always confirm an applied change.
  * Added verification guidance, including identifier lookup and testing considerations for transport, timeout, empty-result, and asynchronous scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->